### PR TITLE
Migrate UNODB_DETAIL_LIKELY/UNODB_DETAIL_UNLIKELY to C++20 [[likely]]/[[unlikely]]

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -7,6 +7,8 @@ filter=-build/include_order,
 filter=-build/include_subdir,
 # Nice but reports a false positive in qsbr.hpp on std::max
 filter=-build/include_what_you_use,
+# False positives with [[likely]] and [[unlikely]]
+filter=-readability/braces,
 # clang-tidy owns NOLINT
 filter=-readability/nolint,
 filter=-runtime/references,

--- a/art.hpp
+++ b/art.hpp
@@ -573,7 +573,8 @@ inline void db::scan(FN fn, bool fwd) {
     it.first();
     visitor<db::iterator> v{it};
     while (it.valid()) {
-      if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+      if (fn(v)) [[unlikely]]
+        break;
       it.next();
     }
   } else {
@@ -581,7 +582,8 @@ inline void db::scan(FN fn, bool fwd) {
     it.last();
     visitor<db::iterator> v{it};
     while (it.valid()) {
-      if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+      if (fn(v)) [[unlikely]]
+        break;
       it.prior();
     }
   }
@@ -596,7 +598,8 @@ inline void db::scan_from(key from_key, FN fn, bool fwd) {
     it.seek(from_key_, match, true /*fwd*/);
     visitor<db::iterator> v{it};
     while (it.valid()) {
-      if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+      if (fn(v)) [[unlikely]]
+        break;
       it.next();
     }
   } else {
@@ -604,7 +607,8 @@ inline void db::scan_from(key from_key, FN fn, bool fwd) {
     it.seek(from_key_, match, false /*fwd*/);
     visitor<db::iterator> v{it};
     while (it.valid()) {
-      if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+      if (fn(v)) [[unlikely]]
+        break;
       it.prior();
     }
   }
@@ -629,7 +633,8 @@ inline void db::scan_range(key from_key, const key to_key, FN fn) {
     }
     visitor<db::iterator> v{it};
     while (it.valid() && it.cmp(to_key_) < 0) {
-      if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+      if (fn(v)) [[unlikely]]
+        break;
       it.next();
       if constexpr (debug) {
         std::cerr << "scan_range:: next()\n";
@@ -646,7 +651,8 @@ inline void db::scan_range(key from_key, const key to_key, FN fn) {
     }
     visitor<db::iterator> v{it};
     while (it.valid() && it.cmp(to_key_) > 0) {
-      if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+      if (fn(v)) [[unlikely]]
+        break;
       it.prior();
       if constexpr (debug) {
         std::cerr << "scan_range:: prior()\n";

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -160,7 +160,7 @@ template <class Header, class Db>
                                     Db &db UNODB_DETAIL_LIFETIMEBOUND) {
   using leaf_type = basic_leaf<Header>;
 
-  if (UNODB_DETAIL_UNLIKELY(v.size() > leaf_type::max_value_size)) {
+  if (v.size() > leaf_type::max_value_size) [[unlikely]] {
     throw std::length_error("Value length must fit in std::uint32_t");
   }
 

--- a/global.hpp
+++ b/global.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2022 Laurynas Biveinis
+// Copyright 2019-2025 Laurynas Biveinis
 #ifndef UNODB_DETAIL_GLOBAL_HPP
 #define UNODB_DETAIL_GLOBAL_HPP
 
@@ -102,8 +102,11 @@
 
 #endif
 
+// Use only in the contexts where C++20 [[likely]] and [[unlikely]] are illegal,
+// i.e. in subexpressions, return statements, ternary operator.
 #define UNODB_DETAIL_LIKELY(x) __builtin_expect(x, 1)
 #define UNODB_DETAIL_UNLIKELY(x) __builtin_expect(x, 0)
+
 #define UNODB_DETAIL_UNUSED [[gnu::unused]]
 #define UNODB_DETAIL_FORCE_INLINE __attribute__((always_inline))
 #define UNODB_DETAIL_NOINLINE __attribute__((noinline))
@@ -113,8 +116,12 @@
 #else  // #ifndef UNODB_DETAIL_MSVC
 
 #define UNODB_DETAIL_BUILTIN_ASSUME(x) __assume(x)
+
+// Use only in the contexts where C++20 [[likely]] and [[unlikely]] are illegal,
+// i.e. in subexpressions, return statements, ternary operator.
 #define UNODB_DETAIL_LIKELY(x) (!!(x))
 #define UNODB_DETAIL_UNLIKELY(x) (!!(x))
+
 #define UNODB_DETAIL_UNUSED [[maybe_unused]]
 #define UNODB_DETAIL_FORCE_INLINE __forceinline
 #define UNODB_DETAIL_NOINLINE __declspec(noinline)

--- a/heap.hpp
+++ b/heap.hpp
@@ -45,7 +45,8 @@ template <typename T>
 
 #ifndef _MSC_VER
   const auto err = posix_memalign(&result, alignment, size);
-  if (UNODB_DETAIL_UNLIKELY(err != 0)) result = nullptr;
+  if (err != 0) [[unlikely]]
+    result = nullptr;  // LCOV_EXCL_LINE
 #else
   result = _aligned_malloc(size, alignment);
 #ifndef NDEBUG
@@ -57,8 +58,8 @@ template <typename T>
   // NOLINTNEXTLINE(readability-simplify-boolean-expr)
   UNODB_DETAIL_ASSERT(result != nullptr || err == ENOMEM);
 
-  if (UNODB_DETAIL_UNLIKELY(result == nullptr)) {
-    throw std::bad_alloc{};
+  if (result == nullptr) [[unlikely]] {
+    throw std::bad_alloc{};  // LCOV_EXCL_LINE
   }
 
   return result;

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -486,7 +486,8 @@ class olc_db final {
       it.first();
       visitor<olc_db::iterator> v{it};
       while (it.valid()) {
-        if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+        if (fn(v)) [[unlikely]]
+          break;
         it.next();
       }
     } else {
@@ -494,7 +495,8 @@ class olc_db final {
       it.last();
       visitor<olc_db::iterator> v{it};
       while (it.valid()) {
-        if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+        if (fn(v)) [[unlikely]]
+          break;
         it.prior();
       }
     }
@@ -521,7 +523,8 @@ class olc_db final {
       it.seek(from_key_, match, true /*fwd*/);
       visitor<olc_db::iterator> v{it};
       while (it.valid()) {
-        if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+        if (fn(v)) [[unlikely]]
+          break;
         it.next();
       }
     } else {
@@ -529,7 +532,8 @@ class olc_db final {
       it.seek(from_key_, match, false /*fwd*/);
       visitor<olc_db::iterator> v{it};
       while (it.valid()) {
-        if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+        if (fn(v)) [[unlikely]]
+          break;
         it.prior();
       }
     }
@@ -574,7 +578,8 @@ class olc_db final {
       }
       visitor<olc_db::iterator> v{it};
       while (it.valid() && it.cmp(to_key_) < 0) {
-        if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+        if (fn(v)) [[unlikely]]
+          break;
         it.next();
         if constexpr (debug) {
           std::cerr << "scan: next()\n";
@@ -591,7 +596,8 @@ class olc_db final {
       }
       visitor<olc_db::iterator> v{it};
       while (it.valid() && it.cmp(to_key_) > 0) {
-        if (UNODB_DETAIL_UNLIKELY(fn(v))) break;
+        if (fn(v)) [[unlikely]]
+          break;
         it.prior();
         if constexpr (debug) {
           std::cerr << "scan: prior()\n";

--- a/qsbr.hpp
+++ b/qsbr.hpp
@@ -13,6 +13,12 @@
 #include "global.hpp"  // IWYU pragma: keep
 
 // IWYU pragma: no_include <__fwd/ostream.h>
+// IWYU pragma: no_include <__ostream/basic_ostream.h>
+// IWYU pragma: no_include <boost/fusion/algorithm/iteration/for_each.hpp>
+// IWYU pragma: no_include <boost/fusion/algorithm/query/find_if.hpp>
+// IWYU pragma: no_include <boost/fusion/iterator/next.hpp>
+// IWYU pragma: no_include <boost/fusion/sequence/intrinsic/begin.hpp>
+// IWYU pragma: no_include <boost/fusion/sequence/intrinsic/end.hpp>
 // IWYU pragma: no_include <boost/fusion/iterator/deref.hpp>
 
 #include <atomic>
@@ -943,7 +949,7 @@ inline void qsbr_per_thread::on_next_epoch_deallocate(
   const auto single_thread_mode =
       qsbr_state::single_thread_mode(current_qsbr_state);
 
-  if (UNODB_DETAIL_UNLIKELY(single_thread_mode)) {
+  if (single_thread_mode) [[unlikely]] {
     advance_last_seen_epoch(single_thread_mode, current_global_epoch);
     qsbr::deallocate(pointer
 #ifndef NDEBUG
@@ -1029,7 +1035,7 @@ inline void qsbr_per_thread::update_requests(
   current_interval_total_dealloc_size = 0;
 #endif  // UNODB_DETAIL_WITH_STATS
 
-  if (UNODB_DETAIL_LIKELY(!single_thread_mode)) {
+  if (!single_thread_mode) [[likely]] {
     previous_interval_dealloc_requests =
         std::move(current_interval_dealloc_requests);
   } else {

--- a/test/qsbr_test_utils.cpp
+++ b/test/qsbr_test_utils.cpp
@@ -1,7 +1,4 @@
-// Copyright 2021-2024 Laurynas Biveinis
-
-// IWYU pragma: no_include <string>
-// IWYU pragma: no_include "gtest/gtest.h"
+// Copyright 2021-2025 Laurynas Biveinis
 
 //
 // CAUTION: [global.hpp] MUST BE THE FIRST INCLUDE IN ALL SOURCE AND
@@ -12,6 +9,10 @@
 // after those symbols are defined, then that results in different
 // container internal structure layouts and that is Not Good.
 #include "global.hpp"  // IWYU pragma: keep
+
+// IWYU pragma: no_include <string>
+// IWYU pragma: no_include <gtest/gtest.h>
+// IWYU pragma: no_include "gtest/gtest.h"
 
 #include "gtest_utils.hpp"
 #include "qsbr.hpp"

--- a/test_heap.cpp
+++ b/test_heap.cpp
@@ -29,7 +29,8 @@ void* operator new(std::size_t count) {
   while (true) {
     // NOLINTNEXTLINE(cppcoreguidelines-no-malloc,cppcoreguidelines-owning-memory,hicpp-no-malloc)
     void* const result = malloc(count);
-    if (UNODB_DETAIL_LIKELY(result != nullptr)) return result;
+    if (result != nullptr) [[likely]]
+      return result;
     // LCOV_EXCL_START
     auto* new_handler = std::get_new_handler();
     if (new_handler == nullptr) throw std::bad_alloc{};


### PR DESCRIPTION
Leave the macros around for the cases the C++20 statement attributes don't
cover (i.e. subexpressions, return statement).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Style**
  - Updated code to use C++20 `[[likely]]` and `[[unlikely]]` attributes instead of macros across multiple files
  - Improved branch prediction hints in various code sections

- **Documentation**
  - Updated copyright year to 2025 in some files
  - Added clarifying comments about macro usage

- **Chores**
  - Added IWYU pragmas to suppress include warnings in some header files
  - Minor code readability improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->