### PR TITLE
Replace the two-way comparison operators in qsbr_ptr with the three-way one

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,7 +152,7 @@ jobs:
       - run:
           name: Build
           working_directory: build
-          command: make -j2 -k
+          command: make -k
       - run:
           name: Correctness test
           working_directory: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,9 @@ set(CLANG_CXX_WARNING_FLAGS
   "-Wunused-macros" "-Wunused-member-function" "-Wunused-template"
   "-Wused-but-marked-unused" "-Wvector-conversion" "-Wvla"
   "-Wweak-template-vtables" "-Wweak-vtables" "-Wzero-as-null-pointer-constant")
+# Workaround https://github.com/llvm/llvm-project/issues/43670 - a spurious
+# warning with the spaceship operator
+set(CLANG_11_CXX_WARNING_FLAGS "-Wno-zero-as-null-pointer-constant")
 set(CLANG_LT_13_CXX_WARNING_FLAGS "-Wreserved-id-macro")
 set(CLANG_GE_13_CXX_WARNING_FLAGS "-Wreserved-identifier")
 
@@ -400,6 +403,8 @@ set(cxx_ge_12 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12.0>")
 set(cxx_lt_13 "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,13.0>")
 set(cxx_ge_13 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,13.0>")
 set(cxx_ge_14 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14.0>")
+set(cxx_lt_12 "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,12.0>")
+set(is_clang11_not_windows "$<AND:${is_clang_not_windows},${cxx_ge_11},${cxx_lt_12}>")
 set(is_clang_lt_13_not_windows "$<AND:${is_clang_not_windows},${cxx_lt_13}>")
 set(is_clang_ge_13_not_windows "$<AND:${is_clang_not_windows},${cxx_ge_13}>")
 set(is_clang_ge_14_not_windows "$<AND:${is_clang_not_windows},${cxx_ge_14}>")
@@ -705,6 +710,7 @@ function(COMMON_TARGET_PROPERTIES TARGET)
     "$<$<AND:${is_standalone},${is_any_msvc}>:${MSVC_CXX_WARNING_FLAGS}>"
     "$<$<AND:${is_standalone},${is_clang_cl}>:${MSVC_CLANG_WARNING_FLAGS}>"
     "$<$<AND:${is_standalone},${is_any_clang_genex},${is_not_windows}>:${CLANG_CXX_WARNING_FLAGS}>"
+    "$<$<AND:${is_standalone},${is_clang11_not_windows}>:${CLANG_11_CXX_WARNING_FLAGS}>"
     "$<$<AND:${is_standalone},${is_clang_lt_13_not_windows}>:${CLANG_LT_13_CXX_WARNING_FLAGS}>"
     "$<$<AND:${is_standalone},${is_clang_ge_13_not_windows}>:${CLANG_GE_13_CXX_WARNING_FLAGS}>"
     "$<$<AND:${is_standalone},${is_gxx_genex}>:${GCC_CXX_WARNING_FLAGS}>"

--- a/qsbr_ptr.hpp
+++ b/qsbr_ptr.hpp
@@ -15,6 +15,7 @@
 
 // IWYU pragma: no_include <__cstddef/byte.h>
 
+#include <compare>  // IWYU pragma: keep
 #include <cstddef>
 #include <iterator>
 #include <ranges>
@@ -257,28 +258,10 @@ class [[nodiscard]] qsbr_ptr : public detail::qsbr_ptr_base {
     return get() == other.get();
   }
 
-  /// Compare less than or equal to \a other.
-  [[nodiscard, gnu::pure]] constexpr bool operator<=(
+  /// Three-way compare to \a other.
+  [[nodiscard, gnu::pure]] constexpr auto operator<=>(
       qsbr_ptr other) const noexcept {
-    return get() <= other.get();
-  }
-
-  /// Compare greater than or equal to \a other.
-  [[nodiscard, gnu::pure]] constexpr bool operator>=(
-      qsbr_ptr other) const noexcept {
-    return get() >= other.get();
-  }
-
-  /// Compare less than \a other.
-  [[nodiscard, gnu::pure]] constexpr bool operator<(
-      qsbr_ptr other) const noexcept {
-    return get() < other.get();
-  }
-
-  /// Compare greater than \a other.
-  [[nodiscard, gnu::pure]] constexpr bool operator>(
-      qsbr_ptr other) const noexcept {
-    return get() > other.get();
+    return get() <=> other.get();
   }
 
   /// Get the raw pointer.

--- a/test/test_qsbr_ptr.cpp
+++ b/test/test_qsbr_ptr.cpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <array>
+#include <compare>  // IWYU pragma: keep
 #include <iterator>
 #include <span>
 #include <utility>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified ordering into a single three-way (spaceship) comparison for pointer-like objects; individual pairwise ordering operators removed.

- **Tests**
  - Test includes updated to support the three-way comparison; test behavior unchanged.

- **Chores**
  - Build system updated with compiler-version checks and flags to accommodate the new comparison support.
  - CI build adjusted to run non-parallel builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->