### PR TITLE
Add support for GCC 15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,66 +36,66 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: GCC 14 Release (Linux Intel)
+          - name: GCC 15 Release (Linux Intel)
             os: ubuntu-latest
             BUILD_TYPE: Release
             COMPILER: gcc
 
-          - name: GCC 14 Release with ASan (Linux Intel)
+          - name: GCC 15 Release with ASan (Linux Intel)
             os: ubuntu-latest
             BUILD_TYPE: Release
             COMPILER: gcc
             SANITIZE_ADDRESS: ON
 
-          - name: GCC 14 Release with TSan (Linux Intel)
+          - name: GCC 15 Release with TSan (Linux Intel)
             os: ubuntu-latest
             BUILD_TYPE: Release
             COMPILER: gcc
             SANITIZE_THREAD: ON
 
-          - name: GCC 14 Release with UBSan (Linux Intel)
+          - name: GCC 15 Release with UBSan (Linux Intel)
             os: ubuntu-latest
             BUILD_TYPE: Release
             COMPILER: gcc
             SANITIZE_UB: ON
 
-          - name: GCC 14 Debug (Linux Intel)
+          - name: GCC 15 Debug (Linux Intel)
             os: ubuntu-latest
             BUILD_TYPE: Debug
             COMPILER: gcc
 
-          - name: GCC 14 Debug with ASan (Linux Intel)
+          - name: GCC 15 Debug with ASan (Linux Intel)
             os: ubuntu-latest
             BUILD_TYPE: Debug
             COMPILER: gcc
             SANITIZE_ADDRESS: ON
 
-          - name: GCC 14 Debug with TSan (Linux Intel)
+          - name: GCC 15 Debug with TSan (Linux Intel)
             os: ubuntu-latest
             BUILD_TYPE: Debug
             COMPILER: gcc
             SANITIZE_THREAD: ON
 
-          - name: GCC 14 Debug with UBSan (Linux Intel)
+          - name: GCC 15 Debug with UBSan (Linux Intel)
             os: ubuntu-latest
             BUILD_TYPE: Debug
             COMPILER: gcc
             SANITIZE_UB: ON
 
-          - name: GCC 14 Debug without AVX2 (Linux Intel)
+          - name: GCC 15 Debug without AVX2 (Linux Intel)
             os: ubuntu-latest
             BUILD_TYPE: Debug
             COMPILER: gcc
             AVX2: OFF
 
-          - name: GCC 14 Release static analysis & cpplint (Linux Intel)
+          - name: GCC 15 Release static analysis & cpplint (Linux Intel)
             os: ubuntu-latest
             BUILD_TYPE: Release
             COMPILER: gcc
             STATIC_ANALYSIS: ON
             CPPLINT: ON
 
-          - name: GCC 14 default CMake configuration (Linux Intel)
+          - name: GCC 15 default CMake configuration (Linux Intel)
             os: ubuntu-latest
             COMPILER: gcc
 
@@ -267,47 +267,47 @@ jobs:
             SANITIZE_UB: ON
             AVX2: OFF
 
-          - name: GCC 14 Release (Linux ARM64)
+          - name: GCC 15 Release (Linux ARM64)
             os: ubuntu-24.04-arm
             BUILD_TYPE: Release
             COMPILER: gcc
 
-          - name: GCC 14 Release with ASan (Linux ARM64)
+          - name: GCC 15 Release with ASan (Linux ARM64)
             os: ubuntu-24.04-arm
             BUILD_TYPE: Release
             COMPILER: gcc
             SANITIZE_ADDRESS: ON
 
-          - name: GCC 14 Release with TSan (Linux ARM64)
+          - name: GCC 15 Release with TSan (Linux ARM64)
             os: ubuntu-24.04-arm
             BUILD_TYPE: Release
             COMPILER: gcc
             SANITIZE_THREAD: ON
 
-          - name: GCC 14 Release with UBSan (Linux ARM64)
+          - name: GCC 15 Release with UBSan (Linux ARM64)
             os: ubuntu-24.04-arm
             BUILD_TYPE: Release
             COMPILER: gcc
             SANITIZE_UB: ON
 
-          - name: GCC 14 Debug (Linux ARM64)
+          - name: GCC 15 Debug (Linux ARM64)
             os: ubuntu-24.04-arm
             BUILD_TYPE: Debug
             COMPILER: gcc
 
-          - name: GCC 14 Debug with ASan (Linux ARM64)
+          - name: GCC 15 Debug with ASan (Linux ARM64)
             os: ubuntu-24.04-arm
             BUILD_TYPE: Debug
             COMPILER: gcc
             SANITIZE_ADDRESS: ON
 
-          - name: GCC 14 Debug with TSan (Linux ARM64)
+          - name: GCC 15 Debug with TSan (Linux ARM64)
             os: ubuntu-24.04-arm
             BUILD_TYPE: Debug
             COMPILER: gcc
             SANITIZE_THREAD: ON
 
-          - name: GCC 14 Debug with UBSan (Linux ARM64)
+          - name: GCC 15 Debug with UBSan (Linux ARM64)
             os: ubuntu-24.04-arm
             BUILD_TYPE: Debug
             COMPILER: gcc
@@ -376,12 +376,13 @@ jobs:
 
       - name: Setup dependencies for GCC
         run: |
-          sudo apt-get install -y g++-14
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
+          sudo apt-get install -y g++-15
         if: runner.os == 'Linux' && env.COMPILER == 'gcc'
 
       - name: Setup multilib dependencies for GCC (x86 only)
         run: |
-          sudo apt-get install -y g++-14-multilib
+          sudo apt-get install -y g++-15-multilib
         if: runner.os == 'Linux' && env.COMPILER == 'gcc' && !contains(matrix.os, 'arm')
 
       - name: Setup dependencies for Linux LLVM (common)
@@ -439,10 +440,9 @@ jobs:
             CBT=""
           fi
           if [[ $COMPILER == "gcc" ]]; then
-            V=14
             EXTRA_CMAKE_ARGS=()
-            export CC=gcc-$V
-            export CXX=g++-$V
+            export CC=gcc
+            export CXX=g++
           elif [[ $COMPILER == "clang" ]]; then
             V=21
             export CC=clang-$V

--- a/.github/workflows/old-compilers-jammy.yml
+++ b/.github/workflows/old-compilers-jammy.yml
@@ -1,5 +1,5 @@
 ---
-name: build-with-old-compilers
+name: build-with-old-compilers-jammy
 
 on:
   push:
@@ -777,7 +777,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install -y g++-13
+          sudo apt-get install -y "g++-${VERSION}"
         if: env.COMPILER == 'gcc' && env.VERSION == '13'
 
       - name: Configure CMake

--- a/.github/workflows/old-compilers-noble.yml
+++ b/.github/workflows/old-compilers-noble.yml
@@ -1,0 +1,120 @@
+---
+name: build-with-old-compilers-noble
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+env:
+  DEFAULT_SANITIZE_ADDRESS: OFF
+  DEFAULT_SANITIZE_THREAD: OFF
+  DEFAULT_SANITIZE_UB: OFF
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+
+    env:
+      BUILD_TYPE: ${{matrix.BUILD_TYPE}}
+      VERSION: ${{matrix.VERSION}}
+      SANITIZE_ADDRESS: ${{matrix.SANITIZE_ADDRESS}}
+      SANITIZE_THREAD: ${{matrix.SANITIZE_THREAD}}
+      SANITIZE_UB: ${{matrix.SANITIZE_UB}}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: GCC 14 Release
+            BUILD_TYPE: Release
+            VERSION: 14
+
+          - name: GCC 14 Release with ASan
+            BUILD_TYPE: Release
+            SANITIZE_ADDRESS: ON
+            VERSION: 14
+
+          - name: GCC 14 Release with TSan
+            BUILD_TYPE: Release
+            SANITIZE_THREAD: ON
+            VERSION: 14
+
+          - name: GCC 14 Release with UBSan
+            BUILD_TYPE: Release
+            SANITIZE_UB: ON
+            VERSION: 14
+
+          - name: GCC 14 Debug
+            BUILD_TYPE: Debug
+            VERSION: 14
+
+          - name: GCC 14 Debug with ASan
+            BUILD_TYPE: Debug
+            SANITIZE_ADDRESS: ON
+            VERSION: 14
+
+          - name: GCC 14 Debug with TSan
+            BUILD_TYPE: Debug
+            SANITIZE_THREAD: ON
+            VERSION: 14
+
+          - name: GCC 14 Debug with UBSan
+            BUILD_TYPE: Debug
+            SANITIZE_UB: ON
+            VERSION: 14
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+          persist-credentials: false
+
+      - name: Setup dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libboost-dev libc6-dev-i386 "g++-${VERSION}"
+
+      - name: Configure CMake
+        # Use a bash shell so we can use the same syntax for environment
+        # variable access regardless of the host operating system
+        shell: bash
+        run: |
+          SANITIZE_ADDRESS="${SANITIZE_ADDRESS:-$DEFAULT_SANITIZE_ADDRESS}"
+          SANITIZE_THREAD="${SANITIZE_THREAD:-$DEFAULT_SANITIZE_THREAD}"
+          SANITIZE_UB="${SANITIZE_UB:-$DEFAULT_SANITIZE_UB}"
+          export CC="gcc-${VERSION}"
+          export CXX="g++-${VERSION}"
+          EXTRA_CMAKE_ARGS=("-DMAINTAINER_MODE=ON")
+          set +e
+          cmake -B build "$GITHUB_WORKSPACE" -DSTANDALONE=ON \
+              "-DCMAKE_BUILD_TYPE=$BUILD_TYPE" \
+              "-DSANITIZE_ADDRESS=${SANITIZE_ADDRESS}" \
+              "-DSANITIZE_THREAD=${SANITIZE_THREAD}" \
+              "-DSANITIZE_UB=${SANITIZE_UB}" \
+              "${EXTRA_CMAKE_ARGS[@]}"
+          CMAKE_EXIT_CODE=$?
+          set -e
+          if [ $CMAKE_EXIT_CODE -ne 0 ]; then
+            if [ -f build/CMakeFiles/CMakeConfigureLog.yaml ]; then
+              echo "::group::CMakeConfigureLog.yaml"
+              cat build/CMakeFiles/CMakeConfigureLog.yaml
+              echo "::endgroup::"
+            fi
+          fi
+          exit $CMAKE_EXIT_CODE
+
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        run: make -j3 -k
+
+      - name: Correctness test
+        working-directory: ${{github.workspace}}/build
+        run: ctest -j3 -V
+
+      - name: Benchmark correctness test
+        working-directory: ${{github.workspace}}/build
+        run: make -k quick_benchmarks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,8 @@ set(GCC_GE_11_CXX_WARNING_FLAGS
 set(GCC_GE_12_CXX_WARNING_FLAGS "-Winterference-size")
 set(GCC_GE_14_CXX_WARNING_FLAGS "-Wnrvo" "-Welaborated-enum-base"
   "-Wdangling-reference")
+set(GCC_GE_15_CXX_WARNING_FLAGS "-Wleading-whitespace=spaces"
+  "-Wtrailing-whitespace=any")
 
 set(UNIX_CXX_FLAGS "-g")
 
@@ -411,6 +413,7 @@ set(cxx_ge_12 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12.0>")
 set(cxx_lt_13 "$<VERSION_LESS:$<CXX_COMPILER_VERSION>,13.0>")
 set(cxx_ge_13 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,13.0>")
 set(cxx_ge_14 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,14.0>")
+set(cxx_ge_15 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,15.0>")
 set(cxx_ge_21 "$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,21.0>")
 set(is_clang_lt_13_not_windows "$<AND:${is_clang_not_windows},${cxx_lt_13}>")
 set(is_clang_ge_13_not_windows "$<AND:${is_clang_not_windows},${cxx_ge_13}>")
@@ -421,6 +424,7 @@ set(is_darwin_clang_ge_21_arm64 "$<AND:$<PLATFORM_ID:Darwin>,${is_clang_ge_21_no
 set(is_gxx_ge_11 "$<AND:${is_gxx_genex},${cxx_ge_11}>")
 set(is_gxx_ge_12 "$<AND:${is_gxx_genex},${cxx_ge_12}>")
 set(is_gxx_ge_14 "$<AND:${is_gxx_genex},${cxx_ge_14}>")
+set(is_gxx_ge_15 "$<AND:${is_gxx_genex},${cxx_ge_15}>")
 # Configuration
 set(has_avx2 "$<BOOL:${AVX2}>")
 set(use_boost_stacktrace "$<BOOL:${USE_BOOST_STACKTRACE}>")
@@ -733,6 +737,7 @@ function(COMMON_TARGET_PROPERTIES TARGET)
     "$<$<AND:${is_standalone},${is_gxx_ge_11}>:${GCC_GE_11_CXX_WARNING_FLAGS}>"
     "$<$<AND:${is_standalone},${is_gxx_ge_12}>:${GCC_GE_12_CXX_WARNING_FLAGS}>"
     "$<$<AND:${is_standalone},${is_gxx_ge_14}>:${GCC_GE_14_CXX_WARNING_FLAGS}>"
+    "$<$<AND:${is_standalone},${is_gxx_ge_15}>:${GCC_GE_15_CXX_WARNING_FLAGS}>"
     # Optimization
     "$<${is_not_release_genex}:$<IF:${is_windows_genex},/Od,-O0>>"
     "$<$<AND:${is_release_genex},${is_not_windows}>:$<IF:${coverage_on},-O0,-O3>>"


### PR DESCRIPTION
- Fix a warning in the codebase
- Enable new non-default warnings
- Bump the versions in CI, move GCC 14 to the old compilers job
- Bump the version in the CMake preset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI to use GCC 15 across build and sanitizer variants, including renaming job labels to reflect GCC 15.
  * Added GCC 15-specific compiler warning flags to enable stricter checks when using GCC 15.
  * Improved legacy-compiler workflows: added a Noble workflow and made older-compiler installs use a dynamic version selection for testing GCC 13/14.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->