### PR TITLE
Install vcpkg gtest & benchmark only for MSVC examples build

### DIFF
--- a/.github/workflows/msvc-build.yml
+++ b/.github/workflows/msvc-build.yml
@@ -71,30 +71,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          vcpkg install boost-accumulators boost-stacktrace:x64-windows-static `
-              gtest benchmark
-
-      - name: Configure CMake (examples)
-        working-directory: examples
-        run: |
-          # Ensure that we use clang-cl from MSVC, not LLVM
-          $env:path = $env:path `
-              -split ';' -notmatch 'C:\\Program Files\\LLVM\\bin' -join ';'
-          cmake --preset "${{matrix.preset}}"
-        if: contains(env.EXAMPLE_PRESETS, matrix.preset)
-
-      - name: Build (examples)
-        working-directory: examples
-        run: |
-          cmake --build --preset "${{matrix.preset}}" -- -k 0
-        if: contains(env.EXAMPLE_PRESETS, matrix.preset)
-
-      - name: Run examples
-        working-directory: examples
-        run: |
-          cmake --build --preset "${{matrix.preset}}" --target examples `
-              -- -k 0
-        if: contains(env.EXAMPLE_PRESETS, matrix.preset)
+          vcpkg install boost-accumulators boost-stacktrace:x64-windows-static
 
       - name: Populate git submodules and configure CMake
         run: |
@@ -129,3 +106,33 @@ jobs:
           $Env:P = "${{matrix.preset}}"
           cmake --build --preset "$env:P" --target quick_benchmarks
         if: "!contains(env.STATIC_ANALYSIS_PRESETS, matrix.preset)"
+
+      # Install the vcpkg test frameworks only after the main build is done:
+      # their headers shadow the 3rd_party/ submodule copies through the vcpkg
+      # toolchain include path, breaking the main build when versions diverge.
+      - name: Install dependencies (examples)
+        run: |
+          vcpkg install gtest benchmark
+        if: contains(env.EXAMPLE_PRESETS, matrix.preset)
+
+      - name: Configure CMake (examples)
+        working-directory: examples
+        run: |
+          # Ensure that we use clang-cl from MSVC, not LLVM
+          $env:path = $env:path `
+              -split ';' -notmatch 'C:\\Program Files\\LLVM\\bin' -join ';'
+          cmake --preset "${{matrix.preset}}"
+        if: contains(env.EXAMPLE_PRESETS, matrix.preset)
+
+      - name: Build (examples)
+        working-directory: examples
+        run: |
+          cmake --build --preset "${{matrix.preset}}" -- -k 0
+        if: contains(env.EXAMPLE_PRESETS, matrix.preset)
+
+      - name: Run examples
+        working-directory: examples
+        run: |
+          cmake --build --preset "${{matrix.preset}}" --target examples `
+              -- -k 0
+        if: contains(env.EXAMPLE_PRESETS, matrix.preset)


### PR DESCRIPTION
vcpkg gtest and benchmark serve only the examples build, which consumes them via `find_package`. Installing them before the main standalone build leaks their headers into it through the vcpkg toolchain include path, shadowing the `3rd_party/` submodule headers while the submodule-built libraries are linked. The mismatch breaks the link whenever the versions diverge on any referenced symbol: gtest 1.17.0 (vcpkg) vs 1.18.0 (submodule) changed `testing::internal::PrintStringTo` to take `std::string_view`, failing Debug configurations with LNK2019 (Release survives as /OPT:REF strips the dangling inline reference).

Move the examples phase after the main build and install its vcpkg dependencies only at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Testing**
  * Updated the Windows build workflow to install testing and benchmarking tools closer to where they are used.
  * Examples now configure, build, and run after the main build when example presets are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->