### PR TITLE
Extract shared ART test data into art_test_data.hpp

### DIFF
--- a/art_test_data.hpp
+++ b/art_test_data.hpp
@@ -1,0 +1,301 @@
+// Copyright 2026 UnoDB contributors
+#ifndef UNODB_DETAIL_ART_TEST_DATA_HPP
+#define UNODB_DETAIL_ART_TEST_DATA_HPP
+
+/// \file
+/// Shared ART test data and key encoding helpers.
+///
+/// \ingroup test-internals
+///
+/// Pure test data (values, key byte patterns), `unodb::key_encoder`-based key
+/// construction helpers, and a helper for copying encoded keys into
+/// caller-owned storage, shared between test and benchmark executables.
+/// Deliberately free of Google Test and database template dependencies so that
+/// any target can include it without linking extra libraries.
+///
+/// \warning The `make_*` builders below return a view into the caller's
+/// `unodb::key_encoder` buffer, not into storage of their own. Such a view is
+/// valid only until the next non-`const` call on that same encoder — any
+/// `make_*` helper, `reset()`, `encode()`, `encode_text()`, `append_bytes()`
+/// or `ensure_available()` — or until that encoder is destroyed. Re-encoding
+/// after `reset()` overwrites the bytes under the view, and outgrowing the
+/// inline buffer moves them out from under it. Either consume the view inside
+/// the full expression that produced it, copy it out with
+/// \ref unodb::test_data::copy_key, or give each simultaneously live key its
+/// own encoder.
+///
+/// The chain-shape notes on the `make_key_*` builders count single-child chain
+/// levels and name every branching inode by the key byte it dispatches on.
+/// They give no absolute depths on purpose: chains are built bottom-up from
+/// the key end, so a level's depth follows the key length and shifts again
+/// whenever a divergence higher up splits an ancestor, while its dispatch byte
+/// does not.
+
+// Should be the first include
+#include "global.hpp"  // IWYU pragma: keep
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <span>
+#include <string_view>
+
+#include "art_common.hpp"
+#include "assert.hpp"
+
+namespace unodb::test_data {
+
+// The byte arrays below are deliberately not `inline`, unlike every other
+// constant in this header. `test_values` constant-initializes a `std::span`
+// over each of them, and under `_GLIBCXX_DEBUG` plus UBSan, GCC 14.2's
+// constexpr evaluator cannot fold the sanitizer-instrumented `ptr + count`
+// inside `__glibcxx_requires_valid_range` when `ptr` is the address of an
+// inline (vague-linkage) variable - "is not a constant expression" - while it
+// folds the same expression over an internal-linkage array. Reproduced with
+// Ubuntu 24.04's g++-14 14.2.0-4ubuntu2~24.04.1; Homebrew GCC 14.4 accepts
+// both. micro_benchmark_utils.hpp's `values` relies on the same shape.
+
+/// Test value of one zero byte.
+constexpr auto test_value_1 = std::array<std::byte, 1>{std::byte{0x00}};
+/// Two-byte test value.
+constexpr auto test_value_2 =
+    std::array<std::byte, 2>{std::byte{0x00}, std::byte{0x02}};
+/// Three-byte test value.
+constexpr auto test_value_3 =
+    std::array<std::byte, 3>{std::byte{0x03}, std::byte{0x00}, std::byte{0x01}};
+/// Four-byte test value.
+constexpr auto test_value_4 = std::array<std::byte, 4>{
+    std::byte{0x04}, std::byte{0x01}, std::byte{0x00}, std::byte{0x02}};
+/// Five-byte test value.
+constexpr auto test_value_5 =
+    std::array<std::byte, 5>{std::byte{0x05}, std::byte{0xF4}, std::byte{0xFF},
+                             std::byte{0x00}, std::byte{0x01}};
+/// Empty test value.
+constexpr auto empty_test_value = std::array<std::byte, 0>{};
+
+/// Views over the test values above, for `unodb::value_view` databases.
+inline constexpr std::array<unodb::value_view, 6> test_values = {
+    unodb::value_view{test_value_1},     // [0] { 00              }
+    unodb::value_view{test_value_2},     // [1] { 00 02           }
+    unodb::value_view{test_value_3},     // [2] { 03 00 01        }
+    unodb::value_view{test_value_4},     // [3] { 04 01 00 02     }
+    unodb::value_view{test_value_5},     // [4] { 05 F4 FF 00 01  }
+    unodb::value_view{empty_test_value}  // [5] {                 }
+};
+
+/// Test values for `std::uint64_t` value databases.
+inline constexpr std::array<std::uint64_t, 6> test_values_u64 = {0, 1, 2,
+                                                                 3, 4, 5};
+
+/// Byte backing the oversize rejection views below.
+inline constexpr std::byte too_long_view_byte{0x00};
+
+/// Length one greater than the maximum supported key or value view size.
+inline constexpr auto too_long_view_length =
+    std::max(static_cast<std::uint64_t>(
+                 std::numeric_limits<unodb::key_size_type>::max()),
+             static_cast<std::uint64_t>(
+                 std::numeric_limits<unodb::value_size_type>::max())) +
+    1U;
+static_assert(too_long_view_length >
+                  static_cast<std::uint64_t>(
+                      std::numeric_limits<unodb::value_size_type>::max()),
+              "No representable over-limit view length exists any more: the "
+              "rejection tests need rethinking, not a bigger constant");
+
+/// A key view too long to be stored in any tree, for rejection tests.
+/// \warning Only the length is real — the view spans a single byte. Never read
+/// through it; pass it only to APIs that reject it by size before touching the
+/// data (currently only insert paths check the size). Deliberately a function
+/// rather than a `constexpr` variable, despite CONTRIBUTING.md's rule: under
+/// `_GLIBCXX_DEBUG` libstdc++'s `std::span` constructor forms `ptr + count`,
+/// and constant-initializing that offset past a single-byte object is not a
+/// core constant expression, which Clang rejects outright.
+[[nodiscard]] inline unodb::key_view too_long_key_view() noexcept {
+  return unodb::key_view{&too_long_view_byte, too_long_view_length};
+}
+
+/// The same view as \ref too_long_key_view, spelled as a value view for
+/// value-rejection tests; the warning there applies here too.
+[[nodiscard]] inline unodb::value_view too_long_value_view() noexcept {
+  return too_long_key_view();
+}
+
+/// String keys exercising text encoding, in insertion order; deliberately not
+/// sorted: inserting `ostritch` (0x6F) after `yellow` (0x79) forces the
+/// mid-array shift branch of `basic_inode_16::add_to_nonfull`.
+inline constexpr std::array<std::string_view, 8> encoded_text_keys{
+    "", "a", "abba", "banana", "camel", "yellow", "ostritch", "zebra"};
+
+/// Filler word giving consecutive key bytes a shared pattern, forcing
+/// key-prefix chains: keys sharing more than key_prefix_capacity (7) bytes
+/// need a chain of internal nodes because the dispatch byte after the stored
+/// prefix is the same for all of them. Only the sharing matters, not the
+/// value: the zero words in \ref make_key_18 and \ref make_key_26 force chains
+/// the same way. 0x42 keeps filler bytes apart from those zero words and from
+/// \ref chain_key_filler_alt in a dump.
+inline constexpr auto chain_key_filler = std::uint64_t{0x4242424242424242ULL};
+
+/// A second filler word, for keys that must diverge from \ref
+/// chain_key_filler at the first byte of the corresponding key word.
+inline constexpr auto chain_key_filler_alt =
+    std::uint64_t{0x4343434343434343ULL};
+
+/// Encode a 9-byte key (uint8 + uint64).
+/// Same tag byte → 8 shared bytes when uint64 values are small.
+[[nodiscard]] inline unodb::key_view make_key(unodb::key_encoder& enc
+                                              UNODB_DETAIL_LIFETIMEBOUND,
+                                              std::uint8_t tag,
+                                              std::uint64_t v) {
+  return enc.reset().encode(tag).encode(v).get_key_view();
+}
+
+/// Encode a 1-byte key (uint8 only).
+/// Diverges at byte 0 from any key with a different first byte.
+/// Its single byte is consumed by one dispatch byte, so the entry sits
+/// directly in the root inode's slot — leaf pointer, or packed value in
+/// can_eliminate_leaf trees — with no key-prefix chain above it.
+[[nodiscard]] inline unodb::key_view make_short_key(unodb::key_encoder& enc
+                                                    UNODB_DETAIL_LIFETIMEBOUND,
+                                                    std::uint8_t tag) {
+  return enc.reset().encode(tag).get_key_view();
+}
+
+/// Encode a 10-byte key (uint8 + uint64 + uint8).
+/// When used with the same tag and v as \ref make_key, the 9-byte key is a
+/// prefix of this 10-byte key — which ART does not support.  Use
+/// different v values to avoid prefix relationships.
+/// Both lengths (9 and 10) exceed key_prefix_capacity + 1 = 8.
+[[nodiscard]] inline unodb::key_view make_long_key(unodb::key_encoder& enc
+                                                   UNODB_DETAIL_LIFETIMEBOUND,
+                                                   std::uint8_t tag,
+                                                   std::uint64_t v,
+                                                   std::uint8_t suffix) {
+  return enc.reset().encode(tag).encode(v).encode(suffix).get_key_view();
+}
+
+/// Copy an encoded key into caller-owned storage; the returned view is
+/// valid for the lifetime of `buf`.
+/// \pre `kv.size() <= buf.size()`. The copy is bounded by `kv`, not by `buf`,
+/// and the returned view's length is `kv.size()`, so an oversize key both
+/// overruns `buf` and yields a view past its end. Enforced only by an assert,
+/// which `NDEBUG` compiles out.
+[[nodiscard]] constexpr unodb::key_view copy_key(
+    unodb::key_view kv,
+    std::span<std::byte> buf UNODB_DETAIL_LIFETIMEBOUND) noexcept {
+  UNODB_DETAIL_ASSERT(kv.size() <= buf.size());
+  std::ranges::copy(kv, buf.begin());
+  return {buf.data(), kv.size()};
+}
+
+/// Encode a 17-byte key: 0xAA × 10, then byte10, then 0xAA × 5, then last.
+/// Two keys sharing byte10 differ only at byte 16: two single-child chain
+/// levels above the inode that branches on byte 16. A key with a different
+/// byte10 diverges inside that inode's prefix and splits it, leaving an inode
+/// branching on byte10 with one byte-16 inode per byte10 value below it.
+[[nodiscard]] inline unodb::key_view make_key_17_byte10(
+    unodb::key_encoder& enc UNODB_DETAIL_LIFETIMEBOUND, std::uint8_t byte10,
+    std::uint8_t last) {
+  enc.reset();
+  for (unsigned i = 0; i < 10; ++i) enc.encode(std::uint8_t{0xAA});
+  enc.encode(byte10);
+  for (unsigned i = 11; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
+  enc.encode(last);
+  return enc.get_key_view();
+}
+
+/// Encode a 17-byte key: 0xAA × 16, then last — \ref make_key_17_byte10 with
+/// the uniform 0xAA prefix. Kept a distinct name rather than an overload so
+/// that an argument-count slip is a compile error instead of a different but
+/// still valid key shape.
+[[nodiscard]] inline unodb::key_view make_key_17(unodb::key_encoder& enc
+                                                 UNODB_DETAIL_LIFETIMEBOUND,
+                                                 std::uint8_t last) {
+  return make_key_17_byte10(enc, std::uint8_t{0xAA}, last);
+}
+
+/// Encode an 18-byte key (uint64 + uint8 + uint64 + uint8).
+/// All keys share bytes [0..7], and within a mid group also bytes [9..16]:
+/// one single-child chain level above the inode that branches on byte 8 =
+/// mid, and one more above each inode that branches on byte 17 = bottom.
+[[nodiscard]] inline unodb::key_view make_key_18(unodb::key_encoder& enc
+                                                 UNODB_DETAIL_LIFETIMEBOUND,
+                                                 std::uint8_t mid,
+                                                 std::uint8_t bottom) {
+  return enc.reset()
+      .encode(chain_key_filler)
+      .encode(mid)
+      .encode(std::uint64_t{0})
+      .encode(bottom)
+      .get_key_view();
+}
+
+/// Encode an 11-byte key (uint8 + uint64 + zero uint8 + uint8).
+/// Keys sharing tag share bytes [0..9] → one single-child chain level above
+/// the inode that branches on byte 10 = bottom (a CD=1 chain cut shape).
+[[nodiscard]] inline unodb::key_view make_key_11(unodb::key_encoder& enc
+                                                 UNODB_DETAIL_LIFETIMEBOUND,
+                                                 std::uint8_t tag,
+                                                 std::uint8_t bottom) {
+  return enc.reset()
+      .encode(tag)
+      .encode(chain_key_filler)
+      .encode(std::uint8_t{0})
+      .encode(bottom)
+      .get_key_view();
+}
+
+/// Encode a 26-byte key (uint8 + uint64 × 3 + uint8).
+/// Two keys sharing tag share 25 bytes: three single-child chain levels above
+/// the inode that branches on byte 25 = bottom. A key with a different tag
+/// diverges at byte 0, splitting the topmost level and adding an inode that
+/// branches on byte 0 above it.
+[[nodiscard]] inline unodb::key_view make_key_26(unodb::key_encoder& enc
+                                                 UNODB_DETAIL_LIFETIMEBOUND,
+                                                 std::uint8_t tag,
+                                                 std::uint8_t bottom) {
+  return enc.reset()
+      .encode(tag)
+      .encode(chain_key_filler)
+      .encode(std::uint64_t{0})
+      .encode(std::uint64_t{0})
+      .encode(bottom)
+      .get_key_view();
+}
+
+/// Encode a 34-byte key (uint8 + uint64 v1 + filler uint64 × 3 + uint8).
+/// Two keys sharing tag and v1 share 33 bytes → four chain levels after the
+/// sibling removal; pass `chain_key_filler` as v1 for the shared chain and
+/// `chain_key_filler_alt` for a key diverging at the first chain level.
+[[nodiscard]] inline unodb::key_view make_key_34(unodb::key_encoder& enc
+                                                 UNODB_DETAIL_LIFETIMEBOUND,
+                                                 std::uint8_t tag,
+                                                 std::uint64_t v1,
+                                                 std::uint8_t bottom) {
+  return enc.reset()
+      .encode(tag)
+      .encode(v1)
+      .encode(chain_key_filler)
+      .encode(chain_key_filler)
+      .encode(chain_key_filler)
+      .encode(bottom)
+      .get_key_view();
+}
+
+/// Decode a `std::uint64_t` key from its encoded form.
+/// \pre `akey.size() >= sizeof(std::uint64_t)`. Only the leading 8 bytes are
+/// read, and `unodb::key_decoder` stores its capacity but never checks it, so
+/// a shorter view is a silent out-of-bounds read.
+[[nodiscard]] inline std::uint64_t decode(unodb::key_view akey) noexcept {
+  UNODB_DETAIL_ASSERT(akey.size() >= sizeof(std::uint64_t));
+  unodb::key_decoder dec{akey};
+  std::uint64_t k;
+  dec.decode(k);
+  return k;
+}
+
+}  // namespace unodb::test_data
+
+#endif  // UNODB_DETAIL_ART_TEST_DATA_HPP

--- a/benchmark/micro_benchmark.cpp
+++ b/benchmark/micro_benchmark.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2025 UnoDB contributors
+// Copyright 2019-2026 UnoDB contributors
 
 // Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
@@ -15,11 +15,14 @@
 
 #include "art_common.hpp"
 #include "art_internal.hpp"  // IWYU pragma: keep
+#include "art_test_data.hpp"
 #include "micro_benchmark_node_utils.hpp"
 #include "micro_benchmark_utils.hpp"
 #include "node_type.hpp"
 
 namespace {
+
+using unodb::test_data::decode;
 
 template <class Db>
 void dense_insert(benchmark::State& state) {
@@ -115,14 +118,6 @@ void dense_full_scan(benchmark::State& state) {
 #ifdef UNODB_DETAIL_WITH_STATS
   unodb::benchmark::set_size_counter(state, "size", tree_size);
 #endif  // UNODB_DETAIL_WITH_STATS
-}
-
-// decode a uint64_t key.
-[[nodiscard]] std::uint64_t decode(unodb::key_view akey) noexcept {
-  unodb::key_decoder dec{akey};
-  std::uint64_t k;
-  dec.decode(k);
-  return k;
 }
 
 // inserts keys and a constant value and then scans all entries in the

--- a/benchmark/micro_benchmark_utils.hpp
+++ b/benchmark/micro_benchmark_utils.hpp
@@ -21,6 +21,7 @@
 
 #include "art.hpp"
 #include "art_common.hpp"
+#include "art_test_data.hpp"
 #ifndef NDEBUG
 #include "assert.hpp"
 #endif
@@ -339,15 +340,11 @@ class key_view_set {
     ks.views_.reserve(n);
     unodb::key_encoder enc;
     for (std::size_t i = 0; i < n; ++i) {
-      const auto kv = enc.reset()
-                          .encode(tag)
-                          .encode(static_cast<std::uint64_t>(i))
-                          .get_key_view();
-      UNODB_DETAIL_DISABLE_MSVC_WARNING(26459)
+      const auto kv =
+          unodb::test_data::make_key(enc, tag, static_cast<std::uint64_t>(i));
       UNODB_DETAIL_DISABLE_MSVC_WARNING(26481)
-      std::copy(kv.begin(), kv.end(), ks.buf_.data() + i * 9);
-      ks.views_.emplace_back(ks.buf_.data() + i * 9, 9);
-      UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+      ks.views_.push_back(
+          unodb::test_data::copy_key(kv, {ks.buf_.data() + i * 9, 9}));
       UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
     }
     return ks;
@@ -366,13 +363,13 @@ class key_view_set {
     for (std::size_t i = 0; i < n; ++i) {
       const auto kv = enc.reset()
                           .encode(tag)
-                          .encode(std::uint64_t{0x4242424242424242ULL})
+                          .encode(unodb::test_data::chain_key_filler)
                           .encode(static_cast<std::uint8_t>(i & 0xFF))
                           .encode(static_cast<std::uint64_t>(i))
                           .get_key_view();
       UNODB_DETAIL_DISABLE_MSVC_WARNING(26481)
-      std::ranges::copy(kv, ks.buf_.data() + i * 18);
-      ks.views_.emplace_back(ks.buf_.data() + i * 18, 18);
+      ks.views_.push_back(
+          unodb::test_data::copy_key(kv, {ks.buf_.data() + i * 18, 18}));
       UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
     }
     return ks;
@@ -393,15 +390,11 @@ class key_view_set {
       UNODB_DETAIL_DISABLE_MSVC_WARNING(26493)
       const auto tag = static_cast<std::uint8_t>(1 + (i % tag_count));
       UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
-      UNODB_DETAIL_DISABLE_MSVC_WARNING(26493)
-      const auto kv = enc.reset()
-                          .encode(tag)
-                          .encode(std::uint64_t{i / tag_count})
-                          .get_key_view();
-      UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+      const auto kv = unodb::test_data::make_key(
+          enc, tag, static_cast<std::uint64_t>(i / tag_count));
       UNODB_DETAIL_DISABLE_MSVC_WARNING(26481)
-      std::ranges::copy(kv, ks.buf_.data() + i * 9);
-      ks.views_.emplace_back(ks.buf_.data() + i * 9, 9);
+      ks.views_.push_back(
+          unodb::test_data::copy_key(kv, {ks.buf_.data() + i * 9, 9}));
       UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
     }
     return ks;
@@ -452,8 +445,8 @@ class key_view_set {
       const auto kv =
           enc.reset().encode(static_cast<std::uint64_t>(i)).get_key_view();
       UNODB_DETAIL_DISABLE_MSVC_WARNING(26481)
-      std::ranges::copy(kv, ks.buf_.data() + i * 8);
-      ks.views_.emplace_back(ks.buf_.data() + i * 8, 8);
+      ks.views_.push_back(
+          unodb::test_data::copy_key(kv, {ks.buf_.data() + i * 8, 8}));
       UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
     }
     return ks;

--- a/modules.dox
+++ b/modules.dox
@@ -26,3 +26,8 @@
 /// Namespace for the UnoDB internal test support code.
 /// \ingroup test-internals
 /// It is not part of the public API, and it may change at any time.
+
+/// \namespace unodb::test_data
+/// Namespace for the shared ART test data and key encoding helpers.
+/// \ingroup test-internals
+/// It is not part of the public API, and it may change at any time.

--- a/test/db_test_utils.hpp
+++ b/test/db_test_utils.hpp
@@ -31,6 +31,7 @@
 #include "art.hpp"
 #include "art_common.hpp"
 #include "art_internal.hpp"
+#include "art_test_data.hpp"
 #include "assert.hpp"
 #include "gtest_utils.hpp"
 #include "mutex_art.hpp"
@@ -73,32 +74,11 @@ template <class TestDb>
 using thread = typename std::conditional_t<is_olc_db<TestDb>,
                                            unodb::qsbr_thread, std::thread>;
 
-constexpr auto test_value_1 = std::array<std::byte, 1>{std::byte{0x00}};
-constexpr auto test_value_2 =
-    std::array<std::byte, 2>{std::byte{0x00}, std::byte{0x02}};
-constexpr auto test_value_3 =
-    std::array<std::byte, 3>{std::byte{0x03}, std::byte{0x00}, std::byte{0x01}};
-constexpr auto test_value_4 = std::array<std::byte, 4>{
-    std::byte{0x04}, std::byte{0x01}, std::byte{0x00}, std::byte{0x02}};
-constexpr auto test_value_5 =
-    std::array<std::byte, 5>{std::byte{0x05}, std::byte{0xF4}, std::byte{0xFF},
-                             std::byte{0x00}, std::byte{0x01}};
-constexpr auto empty_test_value = std::array<std::byte, 0>{};
-
-constexpr std::array<unodb::value_view, 6> test_values = {
-    unodb::value_view{test_value_1},     // [0] { 00              }
-    unodb::value_view{test_value_2},     // [1] { 00 02           }
-    unodb::value_view{test_value_3},     // [2] { 03 00 01        }
-    unodb::value_view{test_value_4},     // [3] { 04 01 00 02     }
-    unodb::value_view{test_value_5},     // [4] { 05 F4 FF 00 01  }
-    unodb::value_view{empty_test_value}  // [5] {                 }
-};
-
-constexpr std::array<std::uint64_t, 6> test_values_u64 = {0, 1, 2, 3, 4, 5};
-
 /// Return a test value appropriate for the db's value type.
 template <class Db>
 constexpr typename Db::value_type get_test_value(std::size_t i) {
+  using unodb::test_data::test_values;
+  using unodb::test_data::test_values_u64;
   if constexpr (std::is_same_v<typename Db::value_type, unodb::value_view>)
     return test_values[i % test_values.size()];
   else
@@ -459,10 +439,7 @@ class [[nodiscard]] tree_verifier final {
   void insert_key_range_internal(key_type start_key, std::size_t count,
                                  bool bypass_verifier = false) {
     if constexpr (std::is_same_v<key_type, key_view>) {
-      // decode to figure out the start key for the loop.
-      unodb::key_decoder dec(start_key);
-      std::uint64_t start_key_dec;
-      dec.decode(start_key_dec);
+      const auto start_key_dec = unodb::test_data::decode(start_key);
       unodb::key_encoder enc;
       for (auto key = start_key_dec; key < start_key_dec + count; ++key) {
         insert(enc.reset().encode(key).get_key_view(), get_test_value<Db>(key),
@@ -514,9 +491,7 @@ class [[nodiscard]] tree_verifier final {
   void preinsert_key_range_to_verifier_only(T start_key1, std::size_t count) {
     const auto start_key{coerce_key(start_key1)};
     if constexpr (std::is_same_v<key_type, key_view>) {
-      unodb::key_decoder dec(start_key);
-      std::uint64_t start_key_dec;
-      dec.decode(start_key_dec);
+      const auto start_key_dec = unodb::test_data::decode(start_key);
       unodb::key_encoder enc;
       for (auto key = start_key_dec; key < start_key_dec + count; ++key) {
         auto tmp = to_ikey(enc.reset().encode(key).get_key_view());
@@ -539,9 +514,7 @@ class [[nodiscard]] tree_verifier final {
   void insert_preinserted_key_range(T start_key1, std::size_t count) {
     const auto start_key{coerce_key(start_key1)};
     if constexpr (std::is_same_v<key_type, key_view>) {
-      unodb::key_decoder dec(start_key);
-      std::uint64_t start_key_dec;
-      dec.decode(start_key_dec);
+      const auto start_key_dec = unodb::test_data::decode(start_key);
       unodb::key_encoder enc;
       for (auto key = start_key_dec; key < start_key_dec + count; ++key) {
         do_insert(enc.reset().encode(key).get_key_view(),

--- a/test/test_art.cpp
+++ b/test/test_art.cpp
@@ -3,19 +3,17 @@
 // Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
 
-// IWYU pragma: no_include <__cstddef/byte.h>
 // IWYU pragma: no_include <array>
 // IWYU pragma: no_include <string>
 
-#include <cstddef>  // IWYU pragma: keep
 #include <cstdint>
-#include <limits>
 #include <stdexcept>
 #include <tuple>
 
 #include <gtest/gtest.h>
 
 #include "art_common.hpp"
+#include "art_test_data.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
 #include "test_utils.hpp"
@@ -23,7 +21,7 @@
 
 namespace {
 using unodb::detail::thread_syncs;
-using unodb::test::test_values;
+using unodb::test_data::test_values;
 /// For key_view types, build_chain creates 1 chain I4 per 8-byte key.
 /// These are counter adjustment values (0 or 1), not booleans.
 template <class Db>
@@ -71,7 +69,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeEmptyValue) {
 
 UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeNonemptyValue) {
   unodb::test::tree_verifier<TypeParam> verifier;
-  verifier.insert(1, unodb::test::test_values[2]);
+  verifier.insert(1, test_values[2]);
 
   verifier.check_present_values();
   verifier.check_absent_keys({0, 2});
@@ -84,15 +82,10 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeNonemptyValue) {
 }
 
 UNODB_TYPED_TEST(ARTCorrectnessTest, TooLongValue) {
-  constexpr std::byte fake_val{0x00};
-  const unodb::value_view too_long{
-      &fake_val,
-      static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) +
-          1U};
-
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  UNODB_ASSERT_THROW(std::ignore = verifier.try_insert(1, too_long),
+  UNODB_ASSERT_THROW(std::ignore = verifier.try_insert(
+                         1, unodb::test_data::too_long_value_view()),
                      std::length_error);
 
   verifier.check_absent_keys({1});
@@ -106,7 +99,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, TooLongValue) {
 UNODB_TYPED_TEST(ARTCorrectnessTest, ExpandLeafToNode4) {
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  verifier.insert(0, unodb::test::test_values[1]);
+  verifier.insert(0, test_values[1]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr auto ci4 = chain_i4_per_key<TypeParam>;
@@ -114,7 +107,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, ExpandLeafToNode4) {
   verifier.assert_growing_inodes({ci4, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 
-  verifier.insert(1, unodb::test::test_values[2]);
+  verifier.insert(1, test_values[2]);
 
   verifier.check_present_values();
   verifier.check_absent_keys({2});
@@ -128,7 +121,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, ExpandLeafToNode4) {
 UNODB_TYPED_TEST(ARTCorrectnessTest, DuplicateKey) {
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(0, test_values[0]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr auto ci4 = chain_i4_per_key<TypeParam>;
@@ -138,7 +131,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, DuplicateKey) {
 #endif  // UNODB_DETAIL_WITH_STATS
 
   unodb::test::must_not_allocate([&verifier] {
-    UNODB_ASSERT_FALSE(verifier.try_insert(0, unodb::test::test_values[3]));
+    UNODB_ASSERT_FALSE(verifier.try_insert(0, test_values[3]));
   });
 
   verifier.check_present_values();
@@ -182,8 +175,8 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node4InsertFFByte) {
 UNODB_TYPED_TEST(ARTCorrectnessTest, TwoNode4) {
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  verifier.insert(1, unodb::test::test_values[0]);
-  verifier.insert(3, unodb::test::test_values[2]);
+  verifier.insert(1, test_values[0]);
+  verifier.insert(3, test_values[2]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr auto ci4 = chain_i4_per_key<TypeParam>;
@@ -191,7 +184,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, TwoNode4) {
 #endif  // UNODB_DETAIL_WITH_STATS
 
   // Insert a value that does not share full prefix with the current Node4
-  verifier.insert(0xFF01, unodb::test::test_values[3]);
+  verifier.insert(0xFF01, test_values[3]);
 
   verifier.check_present_values();
   verifier.check_absent_keys({0xFF00, 2});
@@ -206,10 +199,10 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, TwoNode4) {
 UNODB_TYPED_TEST(ARTCorrectnessTest, DbInsertNodeRecursion) {
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  verifier.insert(1, unodb::test::test_values[0]);
-  verifier.insert(3, unodb::test::test_values[2]);
+  verifier.insert(1, test_values[0]);
+  verifier.insert(3, test_values[2]);
   // Insert a value that does not share full prefix with the current Node4
-  verifier.insert(0xFF0001, unodb::test::test_values[3]);
+  verifier.insert(0xFF0001, test_values[3]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr auto ci4 = chain_i4_per_key<TypeParam>;
@@ -219,7 +212,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, DbInsertNodeRecursion) {
 
   // Then insert a value that shares full prefix with the above node and will
   // ask for a recursive insertion there
-  verifier.insert(0xFF0101, unodb::test::test_values[1]);
+  verifier.insert(0xFF0101, test_values[1]);
 
   verifier.check_present_values();
   verifier.check_absent_keys({0xFF0100, 0xFF0000, 2});
@@ -237,7 +230,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node16) {
 
   verifier.insert_key_range(0, 4);
   verifier.check_present_values();
-  verifier.insert(5, unodb::test::test_values[0]);
+  verifier.insert(5, test_values[0]);
 
   verifier.check_present_values();
   verifier.check_absent_keys({6ULL, 0x0100ULL, 0xFFFFFFFFFFFFFFFFULL});
@@ -268,7 +261,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node16KeyPrefixSplit) {
   verifier.insert_key_range(10, 5);
 
   // Insert a value that does share full prefix with the current Node16
-  verifier.insert(0x1020, unodb::test::test_values[0]);
+  verifier.insert(0x1020, test_values[0]);
 
   verifier.check_present_values();
   verifier.check_absent_keys({9, 0x10FF});
@@ -284,12 +277,12 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node16KeyPrefixSplit) {
 UNODB_TYPED_TEST(ARTCorrectnessTest, Node16KeyInsertOrderDescending) {
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  verifier.insert(5, unodb::test::test_values[0]);
-  verifier.insert(4, unodb::test::test_values[1]);
-  verifier.insert(3, unodb::test::test_values[2]);
-  verifier.insert(2, unodb::test::test_values[3]);
-  verifier.insert(1, unodb::test::test_values[4]);
-  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(5, test_values[0]);
+  verifier.insert(4, test_values[1]);
+  verifier.insert(3, test_values[2]);
+  verifier.insert(2, test_values[3]);
+  verifier.insert(1, test_values[4]);
+  verifier.insert(0, test_values[0]);
 
   verifier.check_present_values();
   verifier.check_absent_keys({6});
@@ -308,7 +301,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node16ConstructWithFFKeyByte) {
   verifier.assert_node_counts({4, 1, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
 
-  verifier.insert(0xFF, unodb::test::test_values[0]);
+  verifier.insert(0xFF, test_values[0]);
 
   verifier.check_present_values();
   verifier.check_absent_keys({0, 0xFA});
@@ -360,7 +353,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node48KeyPrefixSplit) {
 #endif  // UNODB_DETAIL_WITH_STATS
 
   // Insert a value that does share full prefix with the current Node48
-  verifier.insert(0x100020, unodb::test::test_values[0]);
+  verifier.insert(0x100020, test_values[0]);
 
   verifier.check_present_values();
   verifier.check_absent_keys({9, 27, 0x100019, 0x100100, 0x110000});
@@ -413,7 +406,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node256KeyPrefixSplit) {
 #endif  // UNODB_DETAIL_WITH_STATS
 
   // Insert a value that does share full prefix with the current Node256
-  verifier.insert(0x100020, unodb::test::test_values[0]);
+  verifier.insert(0x100020, test_values[0]);
 
   verifier.check_present_values();
   verifier.check_absent_keys({19, 69, 0x100019, 0x100100, 0x110000});
@@ -438,7 +431,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, TryDeleteFromEmpty) {
 UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeDelete) {
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  verifier.insert(1, unodb::test::test_values[0]);
+  verifier.insert(1, test_values[0]);
 
   unodb::test::must_not_allocate([&verifier] { verifier.remove(1); });
 
@@ -451,7 +444,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeDelete) {
 UNODB_TYPED_TEST(ARTCorrectnessTest, SingleNodeTreeAttemptDeleteAbsent) {
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  verifier.insert(2, unodb::test::test_values[1]);
+  verifier.insert(2, test_values[1]);
 
   unodb::test::must_not_allocate(
       [&verifier] { verifier.attempt_remove_missing_keys({1, 3, 0xFF02}); });
@@ -551,7 +544,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node4DeleteLowerNode) {
 
   verifier.insert_key_range(0, 2);
   // Insert a value that does not share full prefix with the current Node4
-  verifier.insert(0xFF00, unodb::test::test_values[3]);
+  verifier.insert(0xFF00, test_values[3]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr auto ci4 = chain_i4_per_key<TypeParam>;
@@ -577,7 +570,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node4DeleteKeyPrefixMerge) {
 
   verifier.insert_key_range(0x8001, 2);
   // Insert a value that does not share full prefix with the current Node4
-  verifier.insert(0x90AA, unodb::test::test_values[3]);
+  verifier.insert(0x90AA, test_values[3]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr auto ci4 = chain_i4_per_key<TypeParam>;
@@ -602,9 +595,9 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node4DeleteKeyPrefixMerge) {
 UNODB_TYPED_TEST(ARTCorrectnessTest, Node4DeleteKeyPrefixMerge2) {
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  verifier.insert(0x0000000003020102, unodb::test::test_values[0]);
-  verifier.insert(0x0000000003030302, unodb::test::test_values[1]);
-  verifier.insert(0x0000000100010102, unodb::test::test_values[2]);
+  verifier.insert(0x0000000003020102, test_values[0]);
+  verifier.insert(0x0000000003030302, test_values[1]);
+  verifier.insert(0x0000000100010102, test_values[2]);
 
   unodb::test::must_not_allocate([&verifier] {
     verifier.remove(0x0000000100010102);
@@ -698,7 +691,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node16KeyPrefixMerge) {
 
   verifier.insert_key_range(10, 5);
   // Insert a value that does not share full prefix with the current Node16
-  verifier.insert(0x1020, unodb::test::test_values[0]);
+  verifier.insert(0x1020, test_values[0]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr auto ci4 = chain_i4_per_key<TypeParam>;
@@ -805,7 +798,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node48KeyPrefixMerge) {
 
   verifier.insert_key_range(10, 17);
   // Insert a value that does not share full prefix with the current Node48
-  verifier.insert(0x2010, unodb::test::test_values[1]);
+  verifier.insert(0x2010, test_values[1]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr auto ci4 = chain_i4_per_key<TypeParam>;
@@ -913,7 +906,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node256KeyPrefixMerge) {
 
   verifier.insert_key_range(10, 49);
   // Insert a value that does not share full prefix with the current Node256
-  verifier.insert(0x2010, unodb::test::test_values[1]);
+  verifier.insert(0x2010, test_values[1]);
 
 #ifdef UNODB_DETAIL_WITH_STATS
   constexpr auto ci4 = chain_i4_per_key<TypeParam>;
@@ -938,9 +931,9 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, Node256KeyPrefixMerge) {
 UNODB_TYPED_TEST(ARTCorrectnessTest, MissingKeyWithPresentPrefix) {
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  verifier.insert(0x010000, unodb::test::test_values[0]);
-  verifier.insert(0x000001, unodb::test::test_values[1]);
-  verifier.insert(0x010001, unodb::test::test_values[2]);
+  verifier.insert(0x010000, test_values[0]);
+  verifier.insert(0x000001, test_values[1]);
+  verifier.insert(0x010001, test_values[2]);
 
   unodb::test::must_not_allocate([&verifier] {
     verifier.attempt_remove_missing_keys({0x000002, 0x010100, 0x010002});
@@ -950,8 +943,8 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, MissingKeyWithPresentPrefix) {
 UNODB_TYPED_TEST(ARTCorrectnessTest, MissingKeyMatchingInodePath) {
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  verifier.insert(0x0100, unodb::test::test_values[0]);
-  verifier.insert(0x0200, unodb::test::test_values[1]);
+  verifier.insert(0x0100, test_values[0]);
+  verifier.insert(0x0200, test_values[1]);
 
   unodb::test::must_not_allocate(
       [&verifier] { verifier.attempt_remove_missing_keys({0x0101, 0x0202}); });
@@ -961,9 +954,9 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, MissingKeyMatchingInodePath) {
 
 UNODB_TYPED_TEST(ARTCorrectnessTest, MemoryAccountingDuplicateKeyInsert) {
   unodb::test::tree_verifier<TypeParam> verifier;
-  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(0, test_values[0]);
   unodb::test::must_not_allocate([&verifier] {
-    UNODB_ASSERT_FALSE(verifier.try_insert(0, unodb::test::test_values[1]));
+    UNODB_ASSERT_FALSE(verifier.try_insert(0, test_values[1]));
   });
   verifier.remove(0);
   UNODB_ASSERT_EQ(verifier.get_db().get_current_memory_use(), 0);
@@ -973,7 +966,7 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, MemoryAccountingDuplicateKeyInsert) {
 
 UNODB_TYPED_TEST(ARTCorrectnessTest, Node48InsertIntoDeletedSlot) {
   unodb::test::tree_verifier<TypeParam> verifier;
-  verifier.insert(16865361447928765957ULL, unodb::test::test_values[0]);
+  verifier.insert(16865361447928765957ULL, test_values[0]);
   verifier.insert(7551546784238320931ULL, test_values[1]);
   verifier.insert(10913915230368519832ULL, test_values[2]);
   verifier.insert(3754602112003529886ULL, test_values[3]);
@@ -1036,14 +1029,14 @@ UNODB_TYPED_TEST(ARTCorrectnessTest, TwoInstances) {
     thread_syncs[0].notify();
     thread_syncs[1].wait();
 
-    v2.insert(0, unodb::test::test_values[0]);
+    v2.insert(0, test_values[0]);
     v2.check_present_values();
   });
 
   thread_syncs[0].wait();
   thread_syncs[1].notify();
 
-  v1.insert(0, unodb::test::test_values[1]);
+  v1.insert(0, test_values[1]);
   v1.check_present_values();
 
   second_thread.join();

--- a/test/test_art_bulk_load.cpp
+++ b/test/test_art_bulk_load.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>  // NOLINT(misc-include-cleaner)
 
 #include "art_common.hpp"
+#include "art_test_data.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
 #include "node_type.hpp"
@@ -31,6 +32,7 @@ namespace {
 #ifdef UNODB_DETAIL_WITH_STATS
 using unodb::as_i;
 using unodb::node_type;
+using unodb::test_data::decode;
 #endif
 using unodb::key_view;
 using unodb::value_view;
@@ -382,9 +384,7 @@ UNODB_TEST(BulkLoadStructural, BulkLoadLarge) {
   bool first = true;
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26440)
   db.scan([&](auto& visitor) {
-    unodb::key_decoder dec{visitor.get_key()};
-    std::uint64_t k{};
-    dec.decode(k);
+    const auto k = decode(visitor.get_key());
     if (!first) {
       UNODB_DETAIL_DISABLE_MSVC_WARNING(6326)
       UNODB_DETAIL_DISABLE_MSVC_WARNING(26818)
@@ -468,9 +468,7 @@ UNODB_TEST(BulkLoadStructural, BulkLoadScanOrder) {
   std::size_t count = 0;
   UNODB_DETAIL_DISABLE_MSVC_WARNING(26440)
   db.scan([&](auto& visitor) {
-    unodb::key_decoder dec{visitor.get_key()};
-    std::uint64_t k{};
-    dec.decode(k);
+    const auto k = decode(visitor.get_key());
     if (count > 0) {
       UNODB_EXPECT_GT(k, prev);
     }

--- a/test/test_art_concurrency.cpp
+++ b/test/test_art_concurrency.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include "art_common.hpp"
+#include "art_test_data.hpp"
 #include "assert.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
@@ -32,11 +33,26 @@
 using unodb::test::sync_point_guard;
 #endif
 
+// MSVC C26815 false positive on every `copy_key(make_*(enc, ...), buf)` call
+// below, including inside `make_chain_key`: the analyzer sees the `key_view`
+// returned by the `make_*` builder die at the end of the full expression and
+// concludes the result dangles.  It does not model that `copy_key` copies those
+// bytes into `buf` and returns a view over `buf`, severing the dependency on
+// its `kv` argument - which is exactly why `kv` is left unannotated while `buf`
+// carries UNODB_DETAIL_LIFETIMEBOUND.
+UNODB_DETAIL_DISABLE_MSVC_WARNING(26815)
+
 namespace {
 
 [[nodiscard]] constexpr bool odd(std::uint64_t x) noexcept {
   return static_cast<bool>(x % 2);
 }
+
+using unodb::test_data::copy_key;
+using unodb::test_data::decode;
+using unodb::test_data::make_key;
+using unodb::test_data::make_short_key;
+using unodb::test_data::test_values;
 
 template <class Db>
 class ARTConcurrencyTest : public ::testing::Test {
@@ -99,14 +115,6 @@ class ARTConcurrencyTest : public ::testing::Test {
     }
   }
 
-  // decode a uint64_t key.
-  [[nodiscard]] static std::uint64_t decode(unodb::key_view akey) noexcept {
-    unodb::key_decoder dec{akey};
-    std::uint64_t k;
-    dec.decode(k);
-    return k;
-  }
-
   // test helper for scan() verification.
   static void do_scan_verification(unodb::test::tree_verifier<Db>* verifier,
                                    std::uint64_t key) {
@@ -124,7 +132,7 @@ class ARTConcurrencyTest : public ::testing::Test {
       const auto& akey = decode(v.get_key());  // actual visited key.
       sum += akey;
       const auto expected =  // Note: same value formula as insert().
-          unodb::test::test_values[akey % unodb::test::test_values.size()];
+          test_values[akey % test_values.size()];
       const auto actual = v.get_value();
       // LCOV_EXCL_START
       UNODB_EXPECT_TRUE(std::ranges::equal(actual, expected));
@@ -167,9 +175,7 @@ class ARTConcurrencyTest : public ::testing::Test {
     for (decltype(ops_per_thread) i = 0; i < ops_per_thread; ++i) {
       switch (thread_i % ntasks) {
         case 0: /* insert (same value formula as insert_key_range!) */
-          verifier->try_insert(
-              key,
-              unodb::test::test_values[key % unodb::test::test_values.size()]);
+          verifier->try_insert(key, test_values[key % test_values.size()]);
           break;
         case 1: /* remove */
           verifier->try_remove(key);
@@ -200,9 +206,7 @@ class ARTConcurrencyTest : public ::testing::Test {
       const auto key{key_generator(gen)};
       switch (thread_i % ntasks) {
         case 0: /* insert (same value formula as insert_key_range!) */
-          verifier->try_insert(
-              key,
-              unodb::test::test_values[key % unodb::test::test_values.size()]);
+          verifier->try_insert(key, test_values[key % test_values.size()]);
           break;
         case 1: /* remove */
           verifier->try_remove(key);
@@ -359,12 +363,10 @@ UNODB_TYPED_TEST(ARTConcurrencyTest,
 
 // Helper: encode a 9-byte chain-triggering key into a caller-owned buffer.
 // The returned key_view is valid for the lifetime of `buf`.
-inline unodb::key_view make_chain_key(unodb::key_encoder& enc, std::uint8_t tag,
-                                      std::uint64_t v,
-                                      std::array<std::byte, 9>& buf) {
-  auto kv = enc.reset().encode(tag).encode(v).get_key_view();
-  std::ranges::copy(kv, buf.begin());
-  return {buf.data(), buf.size()};
+[[nodiscard]] inline unodb::key_view make_chain_key(
+    unodb::key_encoder& enc, std::uint8_t tag, std::uint64_t v,
+    std::array<std::byte, 9>& buf UNODB_DETAIL_LIFETIMEBOUND) {
+  return copy_key(make_key(enc, tag, v), buf);
 }
 
 // Chain concurrency tests reuse ARTConcurrencyTest for QSBR setup and
@@ -380,8 +382,7 @@ class ARTChainConcurrencyTest : public ARTConcurrencyTest<Db> {
     unodb::key_encoder enc;
     std::array<std::byte, 9> buf{};
     constexpr auto tag = static_cast<std::uint8_t>(0x42);
-    const auto val =
-        unodb::test::test_values[thread_i % unodb::test::test_values.size()];
+    const auto val = test_values[thread_i % test_values.size()];
     for (std::size_t i = 0; i < ops_per_thread; ++i) {
       const auto v = i;
       const auto key = make_chain_key(enc, tag, v, buf);
@@ -414,8 +415,7 @@ class ARTChainConcurrencyTest : public ARTConcurrencyTest<Db> {
     for (std::size_t i = 0; i < ops_per_thread; ++i) {
       const auto v = key_gen(gen);
       const auto key = make_chain_key(enc, tag, v, buf);
-      const auto val =
-          unodb::test::test_values[v % unodb::test::test_values.size()];
+      const auto val = test_values[v % test_values.size()];
       switch (thread_i % ntasks) {
         case 0:
           std::ignore = db.insert(key, val);
@@ -459,8 +459,7 @@ class ARTChainConcurrencyTest : public ARTConcurrencyTest<Db> {
     for (std::size_t i = 0; i < ops_per_thread; ++i) {
       const auto v = key_gen(gen);
       const auto key = make_chain_key(enc, tag, v, buf);
-      const auto val =
-          unodb::test::test_values[v % unodb::test::test_values.size()];
+      const auto val = test_values[v % test_values.size()];
       switch (i % 3) {
         case 0:
           std::ignore = db.insert(key, val);
@@ -547,6 +546,13 @@ UNODB_TYPED_TEST(ARTChainConcurrencyTest, DISABLED_ChainStressTest) {
 
 #ifndef NDEBUG
 
+// Key construction helpers whose every use is debug-only; see
+// art_test_data.hpp for the encoded key shapes. They sit inside this guard so
+// that NDEBUG builds do not trip clang-tidy's misc-unused-using-decls; the
+// helpers also used unconditionally are declared with the group above.
+using unodb::test_data::make_key_26;
+using unodb::test_data::make_key_34;
+
 // ===================================================================
 // Concurrent chain cut tests with explicit interleavings.
 // Uses thread_syncs (condition variables) for coordination.
@@ -579,28 +585,14 @@ UNODB_TEST(OLCChainCutInterleaved, ConcurrentInsertIntoCutPointParent) {
 
   // 26-byte keys: tag(1) + 3×uint64(24) + bottom(1).
   // A,B share 25 bytes → 3 chain levels after removing B.
-  auto make26 = [&](std::uint8_t tag, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(std::uint64_t{0})
-        .encode(std::uint64_t{0})
-        .encode(bottom)
-        .get_key_view();
-  };
-
   std::array<std::byte, 26> buf_a{};
   std::array<std::byte, 26> buf_b{};
   std::array<std::byte, 26> buf_sib{};
   std::array<std::byte, 26> buf_new{};
-  auto copy_key = [](const unodb::key_view kv, auto& buf) {
-    std::ranges::copy(kv, buf.begin());
-    return unodb::key_view{buf.data(), buf.size()};
-  };
-  const auto key_a = copy_key(make26(0x10, 0x01), buf_a);
-  const auto key_b = copy_key(make26(0x10, 0x02), buf_b);
-  const auto sib = copy_key(make26(0x20, 0x01), buf_sib);
-  const auto new_key = copy_key(make26(0x30, 0x01), buf_new);
+  const auto key_a = copy_key(make_key_26(enc, 0x10, 0x01), buf_a);
+  const auto key_b = copy_key(make_key_26(enc, 0x10, 0x02), buf_b);
+  const auto sib = copy_key(make_key_26(enc, 0x20, 0x01), buf_sib);
+  const auto new_key = copy_key(make_key_26(enc, 0x30, 0x01), buf_new);
 
   UNODB_ASSERT_TRUE(db.insert(key_a, val));
   UNODB_ASSERT_TRUE(db.insert(key_b, val));
@@ -660,32 +652,17 @@ UNODB_TEST(OLCChainCutInterleaved, ConcurrentInsertIntoMidChain) {
   // At SP2: T1 holds chain[2] (stk[3]) + chain_bottom + leaf.
   // chain[0], chain[1], Root-I4 are all unlocked.
   // T2 targets chain[0] (different v1) — only needs Root-I4 + chain[0].
-  constexpr auto X = std::uint64_t{0x4242424242424242ULL};
-  constexpr auto Z = std::uint64_t{0x4343434343434343ULL};
-
-  auto make34 = [&](std::uint8_t tag, std::uint64_t v1, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(v1)
-        .encode(X)
-        .encode(X)
-        .encode(X)
-        .encode(bottom)
-        .get_key_view();
-  };
+  constexpr auto X = unodb::test_data::chain_key_filler;
+  constexpr auto Z = unodb::test_data::chain_key_filler_alt;
 
   std::array<std::byte, 34> buf_a{};
   std::array<std::byte, 34> buf_b{};
   std::array<std::byte, 34> buf_sib{};
   std::array<std::byte, 34> buf_t2{};
-  auto copy_key = [](const unodb::key_view kv, auto& buf) {
-    std::ranges::copy(kv, buf.begin());
-    return unodb::key_view{buf.data(), buf.size()};
-  };
-  const auto key_a = copy_key(make34(0x10, X, 0x01), buf_a);
-  const auto key_b = copy_key(make34(0x10, X, 0x02), buf_b);
-  const auto sib = copy_key(make34(0x20, X, 0x01), buf_sib);
-  const auto t2_key = copy_key(make34(0x10, Z, 0x01), buf_t2);
+  const auto key_a = copy_key(make_key_34(enc, 0x10, X, 0x01), buf_a);
+  const auto key_b = copy_key(make_key_34(enc, 0x10, X, 0x02), buf_b);
+  const auto sib = copy_key(make_key_34(enc, 0x20, X, 0x01), buf_sib);
+  const auto t2_key = copy_key(make_key_34(enc, 0x10, Z, 0x01), buf_t2);
 
   UNODB_ASSERT_TRUE(db.insert(key_a, val));
   UNODB_ASSERT_TRUE(db.insert(key_b, val));
@@ -737,30 +714,15 @@ UNODB_TEST(OLCChainCutInterleaved, ConcurrentRemoveOfSibling) {
   db_type db;
   unodb::key_encoder enc;
 
-  auto make26 = [&](std::uint8_t tag, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(std::uint64_t{0})
-        .encode(std::uint64_t{0})
-        .encode(bottom)
-        .get_key_view();
-  };
-
   std::array<std::byte, 26> buf_a{};
   std::array<std::byte, 26> buf_b{};
-  auto copy_key = [](const unodb::key_view kv, auto& buf) {
-    std::ranges::copy(kv, buf.begin());
-    return unodb::key_view{buf.data(), buf.size()};
-  };
-  const auto key_a = copy_key(make26(0x10, 0x01), buf_a);
-  const auto key_b = copy_key(make26(0x10, 0x02), buf_b);
+  const auto key_a = copy_key(make_key_26(enc, 0x10, 0x01), buf_a);
+  const auto key_b = copy_key(make_key_26(enc, 0x10, 0x02), buf_b);
   // Use a short (1-byte) sibling so that when T2 removes it, the
   // Root-I4 goes to 1 child but prefix merge overflows (0+1+7 > 7),
   // preventing collapse.  Root-I4 stays alive with a new version.
   std::array<std::byte, 1> buf_sib{};
-  const auto sib =
-      copy_key(enc.reset().encode(std::uint8_t{0x20}).get_key_view(), buf_sib);
+  const auto sib = copy_key(make_short_key(enc, 0x20), buf_sib);
 
   UNODB_ASSERT_TRUE(db.insert(key_a, val));
   UNODB_ASSERT_TRUE(db.insert(key_b, val));
@@ -812,32 +774,17 @@ UNODB_TEST(OLCChainCutInterleaved, ABAOnChainNode) {
   db_type db;
   unodb::key_encoder enc;
 
-  constexpr auto X = std::uint64_t{0x4242424242424242ULL};
-  constexpr auto Z = std::uint64_t{0x4343434343434343ULL};
-
-  auto make34 = [&](std::uint8_t tag, std::uint64_t v1, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(v1)
-        .encode(X)
-        .encode(X)
-        .encode(X)
-        .encode(bottom)
-        .get_key_view();
-  };
+  constexpr auto X = unodb::test_data::chain_key_filler;
+  constexpr auto Z = unodb::test_data::chain_key_filler_alt;
 
   std::array<std::byte, 34> buf_a{};
   std::array<std::byte, 34> buf_b{};
   std::array<std::byte, 34> buf_sib{};
   std::array<std::byte, 34> buf_t2{};
-  auto copy_key = [](const unodb::key_view kv, auto& buf) {
-    std::ranges::copy(kv, buf.begin());
-    return unodb::key_view{buf.data(), buf.size()};
-  };
-  const auto key_a = copy_key(make34(0x10, X, 0x01), buf_a);
-  const auto key_b = copy_key(make34(0x10, X, 0x02), buf_b);
-  const auto sib = copy_key(make34(0x20, X, 0x01), buf_sib);
-  const auto t2_key = copy_key(make34(0x10, Z, 0x01), buf_t2);
+  const auto key_a = copy_key(make_key_34(enc, 0x10, X, 0x01), buf_a);
+  const auto key_b = copy_key(make_key_34(enc, 0x10, X, 0x02), buf_b);
+  const auto sib = copy_key(make_key_34(enc, 0x20, X, 0x01), buf_sib);
+  const auto t2_key = copy_key(make_key_34(enc, 0x10, Z, 0x01), buf_t2);
 
   UNODB_ASSERT_TRUE(db.insert(key_a, val));
   UNODB_ASSERT_TRUE(db.insert(key_b, val));
@@ -1021,20 +968,18 @@ void deep_chain_stress(int n_threads, int ops_per_thread, int iterations) {
   constexpr std::size_t short_key_len = 1;
 
   auto make_deep_key = [](unodb::key_encoder& enc, std::uint8_t variant,
-                          std::array<std::byte, chain_key_len>& buf) {
+                          std::array<std::byte, chain_key_len>& buf
+                          UNODB_DETAIL_LIFETIMEBOUND) {
     enc.reset().encode(std::uint8_t{0x42});
     for (int d = 0; d < chain_depth; ++d) enc.encode(std::uint64_t{0});
     enc.encode(variant);
-    auto kv = enc.get_key_view();
-    std::ranges::copy(kv, buf.begin());
-    return unodb::key_view{buf.data(), buf.size()};
+    return copy_key(enc.get_key_view(), buf);
   };
 
   auto make_short = [](unodb::key_encoder& enc, std::uint8_t tag,
-                       std::array<std::byte, short_key_len>& buf) {
-    auto kv = enc.reset().encode(tag).get_key_view();
-    std::ranges::copy(kv, buf.begin());
-    return unodb::key_view{buf.data(), buf.size()};
+                       std::array<std::byte, short_key_len>& buf
+                       UNODB_DETAIL_LIFETIMEBOUND) {
+    return copy_key(make_short_key(enc, tag), buf);
   };
 
   for (int iter = 0; iter < iterations; ++iter) {
@@ -1463,21 +1408,21 @@ UNODB_TEST(OLCNonfullChainRestart, ConcurrentRemoveDuringChainInsert) {
   using db_type = unodb::olc_db<unodb::key_view, std::uint64_t>;
   db_type db;
   unodb::key_encoder enc;
-  unodb::key_encoder enc2;  // separate encoder for T2
+  // k_seed1 and k_seed2 stay live to the end of the test, and each key view
+  // aliases its encoder's buffer, so each needs its own encoder that is never
+  // re-driven afterwards.
+  unodb::key_encoder enc2;
   constexpr std::uint64_t val = 42;
 
   // Seed: two keys with different first bytes → root I4 with 2 children.
-  const auto k_seed1 = enc.reset().encode(std::uint8_t{0x10}).get_key_view();
+  const auto k_seed1 = make_short_key(enc, 0x10);
   std::ignore = db.insert(k_seed1, val);
-  const auto k_seed2 = enc2.reset().encode(std::uint8_t{0x20}).get_key_view();
+  const auto k_seed2 = make_short_key(enc2, 0x20);
   std::ignore = db.insert(k_seed2, val);
 
   // T1 will insert a long key under 0x30 → add_to_nonfull builds a chain.
   unodb::key_encoder enc_t1;
-  auto t1_key = enc_t1.reset()
-                    .encode(std::uint8_t{0x30})
-                    .encode(std::uint64_t{1})
-                    .get_key_view();
+  const auto t1_key = make_key(enc_t1, 0x30, 1);
 
   const sync_point_guard guard{unodb::detail::sync_before_nonfull_chain_guard};
   unodb::detail::sync_before_nonfull_chain_guard.arm([&]() {
@@ -1493,8 +1438,7 @@ UNODB_TEST(OLCNonfullChainRestart, ConcurrentRemoveDuringChainInsert) {
   auto t2 = unodb::qsbr_thread([&] {
     const unodb::quiescent_state_on_scope_exit q{};
     unodb::detail::thread_syncs[0].wait();
-    std::ignore =
-        db.remove(enc2.reset().encode(std::uint8_t{0x20}).get_key_view());
+    std::ignore = db.remove(k_seed2);
     unodb::detail::thread_syncs[1].notify();
   });
 
@@ -1521,3 +1465,5 @@ UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 #endif  // NDEBUG
 
 }  // namespace
+
+UNODB_DETAIL_RESTORE_MSVC_WARNINGS()

--- a/test/test_art_iter.cpp
+++ b/test/test_art_iter.cpp
@@ -1,4 +1,4 @@
-// Copyright 2024-2025 UnoDB contributors
+// Copyright 2024-2026 UnoDB contributors
 
 // Should be the first include
 #include "global.hpp"  // IWYU pragma: keep
@@ -13,8 +13,8 @@
 
 #include <gtest/gtest.h>
 
-#include "art_common.hpp"
 #include "art_internal.hpp"
+#include "art_test_data.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
 
@@ -27,13 +27,8 @@ class ARTIteratorTest : public ::testing::Test {
   using Test::Test;
 };
 
-// decode a uint64_t key.
-[[nodiscard]] std::uint64_t decode(unodb::key_view akey) noexcept {
-  unodb::key_decoder dec{akey};
-  std::uint64_t k;
-  dec.decode(k);
-  return k;
-}
+using unodb::test_data::decode;
+using unodb::test_data::test_values;
 
 using ARTTypes =
     ::testing::Types<unodb::test::u64_db, unodb::test::u64_mutex_db,
@@ -65,13 +60,12 @@ UNODB_TYPED_TEST(ARTIteratorTest, emptyTreeReverseScan) {
 UNODB_TYPED_TEST(ARTIteratorTest, singleLeafIteratorOneValue) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(0, test_values[0]);
   auto b = db.test_only_iterator();
   b.first();  // obtain iterator.
   UNODB_EXPECT_TRUE(b.valid());
   UNODB_EXPECT_EQ(decode(b.get_key()), 0);
-  UNODB_EXPECT_TRUE(
-      std::ranges::equal(b.get_val(), unodb::test::test_values[0]));
+  UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[0]));
   b.next();                       // advance.
   UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
 }
@@ -80,22 +74,20 @@ UNODB_TYPED_TEST(ARTIteratorTest, singleLeafIteratorOneValue) {
 UNODB_TYPED_TEST(ARTIteratorTest, I4AndTwoLeavesForwardScan) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
   auto b = db.test_only_iterator();
   b.first();  // obtain iterator.
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[0]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[0]));
   }
   b.next();  // advance
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 1);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[1]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[1]));
   }
   b.next();                       // advance.
   UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
@@ -105,22 +97,20 @@ UNODB_TYPED_TEST(ARTIteratorTest, I4AndTwoLeavesForwardScan) {
 UNODB_TYPED_TEST(ARTIteratorTest, I4AndTwoLeavesReverseScan) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
   auto b = db.test_only_iterator();
   b.last();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 1);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[1]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[1]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[0]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[0]));
   }
   b.prior();
   UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
@@ -135,30 +125,27 @@ UNODB_TYPED_TEST(ARTIteratorTest, I4AndTwoLeavesReverseScan) {
 UNODB_TYPED_TEST(ARTIteratorTest, C0001) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0xaa00, unodb::test::test_values[0]);
-  verifier.insert(0xaa01, unodb::test::test_values[1]);
-  verifier.insert(0xab00, unodb::test::test_values[2]);
+  verifier.insert(0xaa00, test_values[0]);
+  verifier.insert(0xaa01, test_values[1]);
+  verifier.insert(0xab00, test_values[2]);
   auto b = db.test_only_iterator();
   b.first();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0xaa00);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[0]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[0]));
   }
   b.next();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0xaa01);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[1]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[1]));
   }
   b.next();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0xab00);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[2]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[2]));
   }
   b.next();
   UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
@@ -173,30 +160,27 @@ UNODB_TYPED_TEST(ARTIteratorTest, C0001) {
 UNODB_TYPED_TEST(ARTIteratorTest, C0002) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0xaa00, unodb::test::test_values[0]);
-  verifier.insert(0xaa01, unodb::test::test_values[1]);
-  verifier.insert(0xab00, unodb::test::test_values[2]);
+  verifier.insert(0xaa00, test_values[0]);
+  verifier.insert(0xaa01, test_values[1]);
+  verifier.insert(0xab00, test_values[2]);
   auto b = db.test_only_iterator();
   b.last();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0xab00);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[2]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[2]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0xaa01);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[1]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[1]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0xaa00);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[0]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[0]));
   }
   b.prior();
   UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
@@ -211,30 +195,27 @@ UNODB_TYPED_TEST(ARTIteratorTest, C0002) {
 UNODB_TYPED_TEST(ARTIteratorTest, C0003) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0xaa00, unodb::test::test_values[0]);
-  verifier.insert(0xab0c, unodb::test::test_values[1]);
-  verifier.insert(0xab0d, unodb::test::test_values[2]);
+  verifier.insert(0xaa00, test_values[0]);
+  verifier.insert(0xab0c, test_values[1]);
+  verifier.insert(0xab0d, test_values[2]);
   auto b = db.test_only_iterator();
   b.first();  // obtain iterators.
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0xaa00);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[0]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[0]));
   }
   b.next();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0xab0c);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[1]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[1]));
   }
   b.next();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0xab0d);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[2]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[2]));
   }
   b.next();
   UNODB_EXPECT_FALSE(b.valid());  // nothing more in the iterator.
@@ -249,30 +230,27 @@ UNODB_TYPED_TEST(ARTIteratorTest, C0003) {
 UNODB_TYPED_TEST(ARTIteratorTest, C0004) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0xaa00, unodb::test::test_values[0]);
-  verifier.insert(0xab0c, unodb::test::test_values[1]);
-  verifier.insert(0xab0d, unodb::test::test_values[2]);
+  verifier.insert(0xaa00, test_values[0]);
+  verifier.insert(0xab0c, test_values[1]);
+  verifier.insert(0xab0d, test_values[2]);
   auto b = db.test_only_iterator();
   b.last();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0xab0d);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[2]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[2]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0xab0c);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[1]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[1]));
   }
   b.prior();
   UNODB_EXPECT_TRUE(b.valid());
   {
     UNODB_EXPECT_EQ(decode(b.get_key()), 0xaa00);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(b.get_val(), unodb::test::test_values[0]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(b.get_val(), test_values[0]));
   }
   b.prior();
   UNODB_EXPECT_FALSE(b.valid());
@@ -310,7 +288,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
   using Key = typename TypeParam::key_type;
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(1, test_values[1]);
   {  // exact match, forward traversal (GTE)
     auto e = db.test_only_iterator();
     bool match = false;
@@ -319,8 +297,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     UNODB_EXPECT_TRUE(it.valid());
     UNODB_EXPECT_EQ(match, true);
     UNODB_EXPECT_EQ(decode(it.get_key()), 1);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[1]));
     it.next();
     UNODB_EXPECT_FALSE(it.valid());
   }
@@ -332,8 +309,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     UNODB_EXPECT_TRUE(it.valid());
     UNODB_EXPECT_TRUE(match);
     UNODB_EXPECT_EQ(decode(it.get_key()), 1);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[1]));
     it.next();
     UNODB_EXPECT_FALSE(it.valid());  // nothing more in the iterator.
   }
@@ -347,8 +323,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     UNODB_EXPECT_TRUE(it.valid());
     UNODB_EXPECT_FALSE(match);
     UNODB_EXPECT_EQ(decode(it.get_key()), 1);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[1]));
     it.next();
     UNODB_EXPECT_FALSE(it.valid());
   }
@@ -379,8 +354,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, singleLeafSeek) {
     UNODB_EXPECT_TRUE(it.valid());
     UNODB_EXPECT_FALSE(match);
     UNODB_EXPECT_EQ(decode(it.get_key()), 1);
-    UNODB_EXPECT_TRUE(
-        std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
+    UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[1]));
     it.next();
     UNODB_EXPECT_FALSE(it.valid());
   }
@@ -399,9 +373,9 @@ UNODB_TYPED_TEST(ARTIteratorTest, C101) {
   constexpr std::uint64_t k0 = 0xaa00;
   constexpr std::uint64_t k1 = 0xaa10;
   constexpr std::uint64_t k2 = 0xab10;
-  verifier.insert(k0, unodb::test::test_values[0]);
-  verifier.insert(k1, unodb::test::test_values[1]);
-  verifier.insert(k2, unodb::test::test_values[2]);
+  verifier.insert(k0, test_values[0]);
+  verifier.insert(k1, test_values[1]);
+  verifier.insert(k2, test_values[2]);
   {    // exact match, forward traversal
     {  // exact match, forward traversal (GTE), first key.
       auto it = db.test_only_iterator();
@@ -411,8 +385,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, C101) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_TRUE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k0);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[0]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[0]));
     }
     {  // exact match, forward traversal (GTE), middle key.
       bool match = false;
@@ -422,8 +395,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, C101) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_TRUE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k1);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[1]));
     }
     {  // exact match, forward traversal (GTE), last key.
       bool match = false;
@@ -433,8 +405,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, C101) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_TRUE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k2);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[2]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[2]));
     }
   }
   {    // exact match, reverse traversal
@@ -446,8 +417,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, C101) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_TRUE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k0);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[0]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[0]));
     }
     {  // exact match, reverse traversal (LTE), middle key.
       bool match = false;
@@ -457,8 +427,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, C101) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_TRUE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k1);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[1]));
     }
     {  // exact match, reverse traversal (LTE), last key.
       bool match = false;
@@ -468,8 +437,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, C101) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_TRUE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k2);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[2]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[2]));
     }
   }
   {    // before and after the first and last key
@@ -483,8 +451,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, C101) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_EQ(match, false);
       UNODB_EXPECT_EQ(decode(it.get_key()), k0);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[0]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[0]));
     }
     {  // forward traversal, after the last key in the data.  match=false
       // and iterator is invalidated.
@@ -513,8 +480,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, C101) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_FALSE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k2);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[2]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[2]));
       it.next();
       UNODB_EXPECT_FALSE(it.valid());  // nothing more in the iterator.
     }
@@ -532,9 +498,9 @@ UNODB_TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
   constexpr std::uint64_t k0 = 0xaa10;
   constexpr std::uint64_t k1 = 0xaa20;
   constexpr std::uint64_t k2 = 0xaa30;
-  verifier.insert(k0, unodb::test::test_values[0]);
-  verifier.insert(k1, unodb::test::test_values[1]);
-  verifier.insert(k2, unodb::test::test_values[2]);
+  verifier.insert(k0, test_values[0]);
+  verifier.insert(k1, test_values[1]);
+  verifier.insert(k2, test_values[2]);
   if (debug) {
     std::cerr << "db state::\n";
     db.dump(std::cerr);
@@ -548,8 +514,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_TRUE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k0);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[0]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[0]));
     }
     {  // exact match, forward traversal (GTE), middle key.
       bool match = false;
@@ -559,8 +524,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_TRUE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k1);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[1]));
     }
     {  // exact match, forward traversal (GTE), last key.
       bool match = false;
@@ -570,8 +534,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_TRUE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k2);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[2]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[2]));
     }
   }
   {    // exact match, reverse traversal
@@ -583,8 +546,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_TRUE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k0);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[0]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[0]));
     }
     {  // exact match, reverse traversal (LTE), middle key.
       bool match = false;
@@ -594,8 +556,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_TRUE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k1);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[1]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[1]));
     }
     {  // exact match, reverse traversal (LTE), last key.
       bool match = false;
@@ -605,8 +566,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_TRUE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k2);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[2]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[2]));
     }
   }
   {    // before and after the first and last key
@@ -624,8 +584,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       UNODB_EXPECT_TRUE(it.valid());
       UNODB_EXPECT_FALSE(match);
       UNODB_EXPECT_EQ(decode(it.get_key()), k0);
-      UNODB_EXPECT_TRUE(
-          std::ranges::equal(it.get_val(), unodb::test::test_values[0]));
+      UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[0]));
     }
     {  // forward traversal, after the last key in the data.
        // match=false and iterator is invalidated.
@@ -667,8 +626,7 @@ UNODB_TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
         UNODB_EXPECT_TRUE(it.valid());
         UNODB_EXPECT_FALSE(match);
         UNODB_EXPECT_EQ(decode(it.get_key()), k2);
-        UNODB_EXPECT_TRUE(
-            std::ranges::equal(it.get_val(), unodb::test::test_values[2]));
+        UNODB_EXPECT_TRUE(std::ranges::equal(it.get_val(), test_values[2]));
         it.next();
         UNODB_EXPECT_FALSE(it.valid());
       }

--- a/test/test_art_key_view.cpp
+++ b/test/test_art_key_view.cpp
@@ -10,7 +10,6 @@
 #include <array>
 #include <cstddef>  // IWYU pragma: keep
 #include <cstdint>
-#include <limits>
 #include <span>
 #include <stdexcept>
 #include <tuple>
@@ -19,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include "art_common.hpp"
+#include "art_test_data.hpp"
 #include "assert.hpp"  // UNODB_DETAIL_ASSERT
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
@@ -40,15 +40,10 @@ UNODB_TYPED_TEST_SUITE(ARTKeyViewCorrectnessTest, ARTTypes)
 /// Unit test of correct rejection of a key which is too large to be
 /// stored in the tree.
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, TooLongKey) {
-  constexpr std::byte fake_val{0x00};
-  const unodb::key_view too_long{
-      &fake_val,
-      static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) +
-          1U};
-
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  UNODB_ASSERT_THROW(std::ignore = verifier.get_db().insert(too_long, {}),
+  UNODB_ASSERT_THROW(std::ignore = verifier.get_db().insert(
+                         unodb::test_data::too_long_key_view(), {}),
                      std::length_error);
 
   verifier.assert_empty();
@@ -63,15 +58,9 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, TooLongKey) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, EncodedTextKeys) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
-  verifier.insert(enc.reset().encode_text("").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("a").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("abba").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("banana").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("camel").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("yellow").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("ostritch").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("zebra").get_key_view(), val);
+  const auto val = unodb::test_data::test_values[0];
+  for (const auto word : unodb::test_data::encoded_text_keys)
+    verifier.insert(enc.reset().encode_text(word).get_key_view(), val);
   verifier.check_present_values();  // checks keys and key ordering.
 }
 
@@ -107,31 +96,12 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, EncodedTextKeys) {
 //     6e. Multi-level chain — 17-byte keys, 2 chain levels
 // ===================================================================
 
-// Helper: encode a 9-byte key (uint8 + uint64).
-// Same tag byte → 8 shared bytes when uint64 values are small.
-inline unodb::key_view make_key(unodb::key_encoder& enc, std::uint8_t tag,
-                                std::uint64_t v) {
-  return enc.reset().encode(tag).encode(v).get_key_view();
-}
-
-// Helper: encode a 1-byte key (uint8 only).
-// Diverges at byte 0 from any key with a different first byte.
-// Used in cascade tests where we need direct-leaf children of the root
-// alongside a chain subtree.
-[[maybe_unused]] inline unodb::key_view make_short_key(unodb::key_encoder& enc,
-                                                       std::uint8_t tag) {
-  return enc.reset().encode(tag).get_key_view();
-}
-
-// Helper: encode a 10-byte key (uint8 + uint64 + uint8).
-// When used with the same tag and v as make_key, the 9-byte key is a
-// prefix of this 10-byte key — which ART does not support.  Use
-// different v values to avoid prefix relationships.
-// Both lengths (9 and 10) exceed key_prefix_capacity + 1 = 8.
-inline unodb::key_view make_long_key(unodb::key_encoder& enc, std::uint8_t tag,
-                                     std::uint64_t v, std::uint8_t suffix) {
-  return enc.reset().encode(tag).encode(v).encode(suffix).get_key_view();
-}
+// Key construction helpers shared with the other test executables; see
+// art_test_data.hpp for the encoded key shapes.
+using unodb::test_data::make_key;
+using unodb::test_data::make_key_17;
+using unodb::test_data::make_key_17_byte10;
+using unodb::test_data::make_long_key;
 
 // -------------------------------------------------------------------
 // Group 0: Original bug reproduction tests
@@ -141,7 +111,7 @@ inline unodb::key_view make_long_key(unodb::key_encoder& enc, std::uint8_t tag,
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysLongSharedPrefix) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -156,7 +126,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysLongSharedPrefix) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ThreeCompoundKeysLongSharedPrefix) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -172,7 +142,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ThreeCompoundKeysLongSharedPrefix) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, NineByteCompoundKeysLongPrefix) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -192,7 +162,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest,
                  CompoundKeysIdenticalExceptLastByte) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -210,17 +180,11 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest,
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MultiLevelChain) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // 17 bytes: 0xAA × 16, then 0x01 vs 0x02.
-  auto make17 = [&](std::uint8_t last) {
-    enc.reset();
-    for (unsigned i = 0; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
-    enc.encode(last);
-    return enc.get_key_view();
-  };
-  verifier.insert(make17(0x01), val);
-  verifier.insert(make17(0x02), val);
+  verifier.insert(make_key_17(enc, 0x01), val);
+  verifier.insert(make_key_17(enc, 0x02), val);
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
   // 2 chain I4s (depth 0→8, 8→16) + bottom I4 (2 children) + 2 leaves
@@ -235,21 +199,13 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest,
                  InsertDivergingAtIntermediateChainDepth) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
-  auto make17 = [&](std::uint8_t byte10, std::uint8_t last) {
-    enc.reset();
-    for (unsigned i = 0; i < 10; ++i) enc.encode(std::uint8_t{0xAA});
-    enc.encode(byte10);
-    for (unsigned i = 11; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
-    enc.encode(last);
-    return enc.get_key_view();
-  };
   // A and B share 16 bytes (byte10=0xAA), differ at byte 16.
-  verifier.insert(make17(0xAA, 0x01), val);
-  verifier.insert(make17(0xAA, 0x02), val);
+  verifier.insert(make_key_17_byte10(enc, 0xAA, 0x01), val);
+  verifier.insert(make_key_17_byte10(enc, 0xAA, 0x02), val);
   // C diverges at byte 10 — splits the second chain node.
-  verifier.insert(make17(0xBB, 0x03), val);
+  verifier.insert(make_key_17_byte10(enc, 0xBB, 0x03), val);
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
   // chain I4 (bytes 0-7) + chain I4 (bytes 8-9, splits at byte 10)
@@ -267,7 +223,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest,
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysFiveChildren) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   for (std::uint64_t i = 1; i <= 5; ++i) {
     verifier.insert(make_key(enc, 0x42, i), val);
@@ -283,7 +239,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysFiveChildren) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysSeventeenChildren) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   for (std::uint64_t i = 1; i <= 17; ++i) {
     verifier.insert(make_key(enc, 0x42, i), val);
@@ -299,7 +255,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysSeventeenChildren) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysFiftyChildren) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   for (std::uint64_t i = 1; i <= 50; ++i) {
     verifier.insert(make_key(enc, 0x42, i), val);
@@ -322,7 +278,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysFiftyChildren) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysInsertThenRemove) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -341,7 +297,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeysInsertThenRemove) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveFromChainLeavesInode) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // Keys 1 and 2 share 8 bytes; key 3 diverges at byte 5.
   // key3 uint64 = 0x0000000100000000 differs at byte 5 (overall).
@@ -360,7 +316,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveFromChainLeavesInode) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveAllFromChainReverseOrder) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -375,7 +331,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveAllFromChainReverseOrder) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveAllFromChainForwardOrder) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -392,7 +348,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveAllFromChainForwardOrder) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ShrinkInode16InChain) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   for (std::uint64_t i = 1; i <= 5; ++i) {
     verifier.insert(make_key(enc, 0x42, i), val);
@@ -411,7 +367,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ShrinkInode16InChain) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ShrinkInode48InChain) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   for (std::uint64_t i = 1; i <= 17; ++i) {
     verifier.insert(make_key(enc, 0x42, i), val);
@@ -431,7 +387,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ShrinkInode48InChain) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ShrinkToEmptyFromInode16InChain) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   for (std::uint64_t i = 1; i <= 5; ++i) {
     verifier.insert(make_key(enc, 0x42, i), val);
@@ -454,7 +410,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ShrinkToEmptyFromInode16InChain) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveMixedLengthFromChain) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_long_key(enc, 0x42, 1, 0xFF), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -475,7 +431,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveMixedLengthFromChain) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, StressInsertRemoveAtEveryPosition) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   constexpr unsigned key_len = 20;
   constexpr unsigned prefix_cap = 7;
@@ -543,7 +499,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, StressInsertRemoveAtEveryPosition) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MixedLengthKeysLongPrefix) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_long_key(enc, 0x42, 1, 0xFF), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -562,7 +518,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MixedLengthKeysLongPrefix) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeyDuplicateInsert) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   // Second insert of same key should fail.
@@ -575,7 +531,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeyDuplicateInsert) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeyGetMissing) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   const auto result = verifier.get_db().get(make_key(enc, 0x42, 2));
@@ -584,6 +540,13 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeyGetMissing) {
 }
 
 #ifdef UNODB_DETAIL_WITH_STATS
+
+// Key construction helpers used only by the stats tests below.
+using unodb::test_data::make_key_11;
+using unodb::test_data::make_key_18;
+using unodb::test_data::make_key_26;
+using unodb::test_data::make_key_34;
+using unodb::test_data::make_short_key;
 
 // ===================================================================
 // Group 6: Stats verification — node counts at intermediate states
@@ -613,7 +576,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CompoundKeyGetMissing) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainPartialRemoveI4) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   for (std::uint64_t i = 1; i <= 3; ++i)
     verifier.insert(make_key(enc, 0x42, i), val);
@@ -629,7 +592,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainPartialRemoveI4) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainShrinkI16ToI4) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   for (std::uint64_t i = 1; i <= 5; ++i)
     verifier.insert(make_key(enc, 0x42, i), val);
@@ -646,7 +609,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainShrinkI16ToI4) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainShrinkI48ToI16) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   for (std::uint64_t i = 1; i <= 17; ++i)
     verifier.insert(make_key(enc, 0x42, i), val);
@@ -663,7 +626,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainShrinkI48ToI16) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainShrinkI256ToI48) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   for (std::uint64_t i = 1; i <= 49; ++i)
     verifier.insert(make_key(enc, 0x42, i), val);
@@ -684,7 +647,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainShrinkI256ToI48) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveAllFromI48) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   for (std::uint64_t i = 1; i <= 17; ++i)
     verifier.insert(make_key(enc, 0x42, i), val);
@@ -697,7 +660,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveAllFromI48) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveAllFromI256) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   for (std::uint64_t i = 1; i <= 49; ++i)
     verifier.insert(make_key(enc, 0x42, i), val);
@@ -722,7 +685,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveAllFromI256) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI4) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // Insert chain keys first so the chain forms at root level, then
   // insert a short key that splits the root prefix → parent I4.
@@ -748,7 +711,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI4) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI16) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // Chain keys first, then 4 short keys → root I16(5 children).
   verifier.insert(make_key(enc, 0x42, 1), val);
@@ -770,7 +733,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI16) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI48) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // Chain keys first, then 16 short keys → root I48(17 children).
   verifier.insert(make_key(enc, 0x42, 1), val);
@@ -791,7 +754,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI48) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI256) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // Chain keys first, then 48 short keys → root I256(49 children).
   verifier.insert(make_key(enc, 0x42, 1), val);
@@ -813,7 +776,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, CascadeChainUnderI256) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveFromI48AboveMin) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -830,7 +793,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveFromI48AboveMin) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveFromI256AboveMin) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -850,23 +813,17 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveFromI256AboveMin) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MultiLevelChainRemoveAll) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
-  auto make17 = [&](std::uint8_t last) {
-    enc.reset();
-    for (unsigned i = 0; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
-    enc.encode(last);
-    return enc.get_key_view();
-  };
-  verifier.insert(make17(0x01), val);
-  verifier.insert(make17(0x02), val);
+  verifier.insert(make_key_17(enc, 0x01), val);
+  verifier.insert(make_key_17(enc, 0x02), val);
   verifier.assert_node_counts({2, 3, 0, 0, 0});
 
-  verifier.remove(make17(0x01));
+  verifier.remove(make_key_17(enc, 0x01));
   // Bottom I4 collapsed.  Two chain I4s remain, last one has 1 child (leaf).
   verifier.assert_node_counts({1, 3, 0, 0, 0});
 
-  verifier.remove(make17(0x02));
+  verifier.remove(make_key_17(enc, 0x02));
   verifier.assert_empty();
 }
 
@@ -881,7 +838,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MultiLevelChainRemoveAll) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI4ToI16) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // Chain subtree under tag=0x42.
   verifier.insert(make_key(enc, 0x42, 1), val);
@@ -898,7 +855,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI4ToI16) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI16ToI48) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -913,7 +870,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI16ToI48) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI48ToI256) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -932,7 +889,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainParentGrowthI48ToI256) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainBottomGrowthStats) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // Insert 4 keys: chain-I4 + bottom-I4(4).
   for (std::uint64_t i = 1; i <= 4; ++i)
@@ -969,28 +926,22 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainBottomGrowthStats) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MultiLevelChainFatBottom) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
-  auto make17 = [&](std::uint8_t last) {
-    enc.reset();
-    for (unsigned i = 0; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
-    enc.encode(last);
-    return enc.get_key_view();
-  };
-
-  for (std::uint8_t i = 1; i <= 5; ++i) verifier.insert(make17(i), val);
+  for (std::uint8_t i = 1; i <= 5; ++i)
+    verifier.insert(make_key_17(enc, i), val);
   verifier.check_present_values();
   // 2 chain-I4s + bottom I16(5) + 5 leaves
   verifier.assert_node_counts({5, 2, 1, 0, 0});
   verifier.assert_growing_inodes({3, 1, 0, 0});
 
   // Remove 1 → I16 at min_size → shrink to I4.
-  verifier.remove(make17(1));
+  verifier.remove(make_key_17(enc, 1));
   verifier.assert_node_counts({4, 3, 0, 0, 0});
   verifier.assert_shrinking_inodes({0, 1, 0, 0});
 
   // Remove remaining → chains collapse.
-  for (std::uint8_t i = 2; i <= 5; ++i) verifier.remove(make17(i));
+  for (std::uint8_t i = 2; i <= 5; ++i) verifier.remove(make_key_17(enc, i));
   verifier.assert_empty();
 }
 
@@ -1010,21 +961,13 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MultiLevelChainFatBottom) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MidLevelInodeGrowth) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
-
-  auto make18 = [&](std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(std::uint64_t{0})
-        .encode(bottom)
-        .get_key_view();
-  };
+  const auto val = unodb::test_data::test_values[0];
 
   // 5 mid groups × 2 bottom keys = 10 keys.
   // Mid-inode at depth 8 grows to I16(5).
   for (std::uint8_t m = 1; m <= 5; ++m)
-    for (std::uint8_t b = 1; b <= 2; ++b) verifier.insert(make18(m, b), val);
+    for (std::uint8_t b = 1; b <= 2; ++b)
+      verifier.insert(make_key_18(enc, m, b), val);
   verifier.check_present_values();
   // chain(0) → mid-I16(5) → 5×(chain(9) → bottom-I4(2) → 2 leaves)
   // I4: 1 top-chain + 5 depth-9-chains + 5 bottoms = 11
@@ -1035,26 +978,18 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MidLevelInodeGrowth) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MidLevelInodeShrink) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
-
-  auto make18 = [&](std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(std::uint64_t{0})
-        .encode(bottom)
-        .get_key_view();
-  };
+  const auto val = unodb::test_data::test_values[0];
 
   // 5 mid groups × 2 bottom keys = 10 keys → mid I16(5).
   for (std::uint8_t m = 1; m <= 5; ++m)
-    for (std::uint8_t b = 1; b <= 2; ++b) verifier.insert(make18(m, b), val);
+    for (std::uint8_t b = 1; b <= 2; ++b)
+      verifier.insert(make_key_18(enc, m, b), val);
 
   // Remove both keys for mid=1 → bottom-I4(2) collapses (I4 shrink),
   // chain(9) collapses (I4 shrink), mid-I16(5) at min_size → I4(4)
   // (I16 shrink).
-  verifier.remove(make18(1, 1));
-  verifier.remove(make18(1, 2));
+  verifier.remove(make_key_18(enc, 1, 1));
+  verifier.remove(make_key_18(enc, 1, 2));
   verifier.check_present_values();
   // chain(0) → mid-I4(4) → 4×(chain(9) → bottom-I4(2) → 2 leaves)
   // I4: 1 top-chain + 4 depth-9-chains + 4 bottoms + 1 mid = 10
@@ -1071,7 +1006,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, MidLevelInodeShrink) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveKeyNotFound) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -1085,7 +1020,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveKeyNotFound) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveMissRootIsLeaf) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   UNODB_ASSERT_FALSE(verifier.get_db().remove(make_key(enc, 0x42, 2)));
@@ -1098,7 +1033,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, RemoveMissRootIsLeaf) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveLeafMismatch) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   verifier.insert(make_key(enc, 0x42, 1), val);
   verifier.insert(make_key(enc, 0x42, 2), val);
@@ -1121,34 +1056,25 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainRemoveLeafMismatch) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1CollapseToLeaf) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
-
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
+  const auto val = unodb::test_data::test_values[0];
 
   // A and B share tag + 8 bytes → chain at depth 0, chain at depth 8.
   // C has different tag → sibling at root.
-  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
-  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
-  verifier.insert(make18(0x02, 0x00, 0x01), val);  // C
+  verifier.insert(make_key_11(enc, 0x01, 0x01), val);  // A
+  verifier.insert(make_key_11(enc, 0x01, 0x02), val);  // B
+  verifier.insert(make_key_11(enc, 0x02, 0x01), val);  // C
   verifier.check_present_values();
 
   // Remove B: bottom I4(2→1), chain extends.
-  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
   verifier.check_present_values();
 
   // Remove A: chain cut (CD=1). Root I4(2→1) collapses to leaf(C).
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
 
   // Remove C: tree empty.
-  verifier.remove(make18(0x02, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x02, 0x01));
   verifier.assert_empty();
 }
 
@@ -1158,7 +1084,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1CollapseToLeaf) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD0CollapseToInode) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // A: 9-byte key with tag=0x10 → chain at depth 0.
   // B,C: 1-byte keys with tag=0x20, 0x30 → I4(2) at root, no prefix.
@@ -1194,33 +1120,24 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD0CollapseToInode) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1CollapseToInode) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
-
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
+  const auto val = unodb::test_data::test_values[0];
 
   // A,B share tag=0x01 + 8 bytes → depth-1 chain → I4(2: A, B).
   // D,E have tag=0x02 → I4(2: D, E) subtree.
   // Root: I4(2: 0x01→chain→chain→I4(A,B), 0x02→chain→I4(D,E))
-  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
-  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
-  verifier.insert(make18(0x02, 0x00, 0x01), val);  // D
-  verifier.insert(make18(0x02, 0x00, 0x02), val);  // E
+  verifier.insert(make_key_11(enc, 0x01, 0x01), val);  // A
+  verifier.insert(make_key_11(enc, 0x01, 0x02), val);  // B
+  verifier.insert(make_key_11(enc, 0x02, 0x01), val);  // D
+  verifier.insert(make_key_11(enc, 0x02, 0x02), val);  // E
   verifier.check_present_values();
 
   // Remove B: bottom I4(2→1) under tag=0x01, chain extends.
-  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
   verifier.check_present_values();
 
   // Remove A: chain cut (CD=1). Root I4(2→1) collapses.
   // Remaining child is the tag=0x02 subtree — prefix merge needed.
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
 }
 
@@ -1228,28 +1145,19 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1CollapseToInode) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1RemoveFromI4) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
-
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
+  const auto val = unodb::test_data::test_values[0];
 
   // 3 tag groups: 0x01 (chain target), 0x02, 0x03.
   // Root: I4(3: chain→...A, leaf(D), leaf(E))
-  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
-  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
-  verifier.insert(make18(0x02, 0x00, 0x01), val);  // D
-  verifier.insert(make18(0x03, 0x00, 0x01), val);  // E
+  verifier.insert(make_key_11(enc, 0x01, 0x01), val);  // A
+  verifier.insert(make_key_11(enc, 0x01, 0x02), val);  // B
+  verifier.insert(make_key_11(enc, 0x02, 0x01), val);  // D
+  verifier.insert(make_key_11(enc, 0x03, 0x01), val);  // E
   verifier.check_present_values();
 
   // Remove B, then A: chain cut from I4(3→2).
-  verifier.remove(make18(0x01, 0x00, 0x02));
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
 }
 
@@ -1260,20 +1168,11 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest,
                  ChainCutCD1CollapseToInodeShortPrefix) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
-
-  // A,B: tag=0x01, 18-byte keys → depth-1 chain → I4(2: A, B).
-  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
-  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
+  // A,B: tag=0x01, 11-byte keys → depth-1 chain → I4(2: A, B).
+  verifier.insert(make_key_11(enc, 0x01, 0x01), val);  // A
+  verifier.insert(make_key_11(enc, 0x01, 0x02), val);  // B
   // C,D: tag=0x02, 2-byte keys → I4(2: C, D) with empty prefix.
   verifier.insert(enc.reset()
                       .encode(std::uint8_t{0x02})
@@ -1288,13 +1187,13 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest,
   verifier.check_present_values();
 
   // Remove B: bottom I4(2→1) under tag=0x01, chain extends.
-  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
   verifier.check_present_values();
 
   // Remove A: chain cut (CD=1). Root I4(2→1) collapses.
   // Remaining child is I4(C,D) with empty prefix.
   // Merge: root prefix(0) + dispatch(0x02) + child prefix(0) = 1 ≤ 7.
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
 }
 
@@ -1302,29 +1201,19 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest,
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD2CollapseToLeaf) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // 26-byte keys: tag + uint64 + uint64 + uint64 + uint8.
   // Two keys sharing 25 bytes → 3 chain levels (depth 0,8,16).
-  auto make26 = [&](std::uint8_t tag, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(std::uint64_t{0})
-        .encode(bottom)
-        .get_key_view();
-  };
-
-  verifier.insert(make26(0x01, 0x01), val);  // A
-  verifier.insert(make26(0x01, 0x02), val);  // B
-  verifier.insert(make26(0x02, 0x01), val);  // sibling
+  verifier.insert(make_key_26(enc, 0x01, 0x01), val);  // A
+  verifier.insert(make_key_26(enc, 0x01, 0x02), val);  // B
+  verifier.insert(make_key_26(enc, 0x02, 0x01), val);  // sibling
   verifier.check_present_values();
 
   // Remove B → chain extends. Remove A → CD=2 chain cut.
-  verifier.remove(make26(0x01, 0x02));
+  verifier.remove(make_key_26(enc, 0x01, 0x02));
   verifier.check_present_values();
-  verifier.remove(make26(0x01, 0x01));
+  verifier.remove(make_key_26(enc, 0x01, 0x01));
   verifier.check_present_values();
 
   // Sibling subtree remains: chain(depth 0)→chain(depth 8)→chain(depth 16)
@@ -1333,7 +1222,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD2CollapseToLeaf) {
   // Prefix overflow prevents collapse at each level.
 
   // Remove sibling → empty.
-  verifier.remove(make26(0x02, 0x01));
+  verifier.remove(make_key_26(enc, 0x02, 0x01));
   verifier.assert_empty();
 }
 
@@ -1342,7 +1231,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD2CollapseToLeaf) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD0PrefixOverflow) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // Both children are 9-byte keys with different tags.
   // Root I4 has empty prefix. Each child chain has 7-byte prefix.
@@ -1372,35 +1261,26 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD0PrefixOverflow) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1PrefixOverflow) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
-
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
+  const auto val = unodb::test_data::test_values[0];
 
   // tag=0x01: 2 keys sharing 10 bytes → CD=1 chain.
   // tag=0x02: 2 keys → chain with 7-byte prefix.
   // Root I4 has empty prefix. 0x02 child has 7-byte prefix.
   // Collapse: 0 + 1 + 7 = 8 → overflow.
-  verifier.insert(make18(0x01, 0x00, 0x01), val);
-  verifier.insert(make18(0x01, 0x00, 0x02), val);
-  verifier.insert(make18(0x02, 0x00, 0x01), val);
-  verifier.insert(make18(0x02, 0x00, 0x02), val);
+  verifier.insert(make_key_11(enc, 0x01, 0x01), val);
+  verifier.insert(make_key_11(enc, 0x01, 0x02), val);
+  verifier.insert(make_key_11(enc, 0x02, 0x01), val);
+  verifier.insert(make_key_11(enc, 0x02, 0x02), val);
   verifier.check_present_values();
 
   // Remove both under tag=0x01 → CD=1 chain cut.
-  verifier.remove(make18(0x01, 0x00, 0x02));
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
 
   // tag=0x02 keys still accessible.
-  verifier.remove(make18(0x02, 0x00, 0x01));
-  verifier.remove(make18(0x02, 0x00, 0x02));
+  verifier.remove(make_key_11(enc, 0x02, 0x01));
+  verifier.remove(make_key_11(enc, 0x02, 0x02));
   verifier.assert_empty();
 }
 
@@ -1408,27 +1288,18 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1PrefixOverflow) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1ShrinkI16) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
-
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
+  const auto val = unodb::test_data::test_values[0];
 
   // 5 tag groups → I16(5) at root level (after chain at depth 0).
   // Under tag=0x01: 2 keys → CD=1 chain.
   for (std::uint8_t t = 1; t <= 5; ++t)
     for (std::uint8_t b = 1; b <= 2; ++b)
-      verifier.insert(make18(t, 0x00, b), val);
+      verifier.insert(make_key_11(enc, t, b), val);
   verifier.check_present_values();
 
   // Remove both under tag=0x01 → CD=1 chain cut from I16(5→4) → I4.
-  verifier.remove(make18(0x01, 0x00, 0x02));
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
   // 8 leaves, 4 tag groups each with chain(depth 0)→chain(depth 8)→I4(2).
   // Top-level I4(4) + 4×(chain + bottom-I4) = 1 + 8 = 9 I4s.
@@ -1440,26 +1311,17 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1ShrinkI16) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1ShrinkI48) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
-
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
+  const auto val = unodb::test_data::test_values[0];
 
   // 17 tag groups → I48(17).
   for (std::uint8_t t = 1; t <= 17; ++t)
     for (std::uint8_t b = 1; b <= 2; ++b)
-      verifier.insert(make18(t, 0x00, b), val);
+      verifier.insert(make_key_11(enc, t, b), val);
   verifier.check_present_values();
 
   // Remove both under tag=0x01 → CD=1 chain cut from I48(17→16) → I16.
-  verifier.remove(make18(0x01, 0x00, 0x02));
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
   // 32 leaves, 16 tag groups each with chain→chain→I4(2).
   // Top-level I16(16) + 16×(chain + bottom-I4) = 0 + 32 = 32 I4s.
@@ -1471,26 +1333,17 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1ShrinkI48) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1ShrinkI256) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
-
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
+  const auto val = unodb::test_data::test_values[0];
 
   // 49 tag groups → I256(49).
   for (std::uint8_t t = 1; t <= 49; ++t)
     for (std::uint8_t b = 1; b <= 2; ++b)
-      verifier.insert(make18(t, 0x00, b), val);
+      verifier.insert(make_key_11(enc, t, b), val);
   verifier.check_present_values();
 
   // Remove both under tag=0x01 → CD=1 chain cut from I256(49→48) → I48.
-  verifier.remove(make18(0x01, 0x00, 0x02));
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
   // 96 leaves, 48 tag groups each with chain→chain→I4(2).
   // Top-level I48(48) + 48×(chain + bottom-I4) = 0 + 96 = 96 I4s.
@@ -1507,31 +1360,21 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ChainCutCD1ShrinkI256) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ConcurrentTestTree26Byte) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
-  auto make26 = [&](std::uint8_t tag, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(std::uint64_t{0})
-        .encode(std::uint64_t{0})
-        .encode(bottom)
-        .get_key_view();
-  };
-
-  verifier.insert(make26(0x10, 0x01), val);  // A
-  verifier.insert(make26(0x10, 0x02), val);  // B
-  verifier.insert(make26(0x20, 0x01), val);  // sib
+  verifier.insert(make_key_26(enc, 0x10, 0x01), val);  // A
+  verifier.insert(make_key_26(enc, 0x10, 0x02), val);  // B
+  verifier.insert(make_key_26(enc, 0x20, 0x01), val);  // sib
   verifier.check_present_values();
 
-  verifier.remove(make26(0x10, 0x02));  // remove B
+  verifier.remove(make_key_26(enc, 0x10, 0x02));  // remove B
   verifier.check_present_values();
 
-  verifier.remove(make26(0x10, 0x01));  // remove A (chain cut)
+  verifier.remove(make_key_26(enc, 0x10, 0x01));  // remove A (chain cut)
   verifier.check_present_values();
 
   // Insert a new key at root level (what CT1's T2 does).
-  verifier.insert(make26(0x30, 0x01), val);
+  verifier.insert(make_key_26(enc, 0x30, 0x01), val);
   verifier.check_present_values();
 }
 
@@ -1540,36 +1383,25 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ConcurrentTestTree26Byte) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ConcurrentTestTree34Byte) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
-  constexpr auto X = std::uint64_t{0x4242424242424242ULL};
-  constexpr auto Z = std::uint64_t{0x4343434343434343ULL};
+  constexpr auto X = unodb::test_data::chain_key_filler;
+  constexpr auto Z = unodb::test_data::chain_key_filler_alt;
 
-  auto make34 = [&](std::uint8_t tag, std::uint64_t v1, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(v1)
-        .encode(X)
-        .encode(X)
-        .encode(X)
-        .encode(bottom)
-        .get_key_view();
-  };
-
-  verifier.insert(make34(0x10, X, 0x01), val);  // A
-  verifier.insert(make34(0x10, X, 0x02), val);  // B
-  verifier.insert(make34(0x20, X, 0x01), val);  // sib
+  verifier.insert(make_key_34(enc, 0x10, X, 0x01), val);  // A
+  verifier.insert(make_key_34(enc, 0x10, X, 0x02), val);  // B
+  verifier.insert(make_key_34(enc, 0x20, X, 0x01), val);  // sib
   verifier.check_present_values();
 
-  verifier.remove(make34(0x10, X, 0x02));  // remove B
+  verifier.remove(make_key_34(enc, 0x10, X, 0x02));  // remove B
   verifier.check_present_values();
 
   // Insert T2's key (diverges at chain[0] level, different v1).
-  verifier.insert(make34(0x10, Z, 0x01), val);
+  verifier.insert(make_key_34(enc, 0x10, Z, 0x01), val);
   verifier.check_present_values();
 
   // Remove A (chain cut with T2's key already in tree).
-  verifier.remove(make34(0x10, X, 0x01));
+  verifier.remove(make_key_34(enc, 0x10, X, 0x01));
   verifier.check_present_values();
 }
 
@@ -1580,7 +1412,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ConcurrentTestTree34Byte) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ScanChainMixedLengths) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // 9-byte and 10-byte keys in the same chain subtree.
   // make_key(0x42, v) = 9 bytes.  make_long_key(0x42, v, s) = 10 bytes.
@@ -1610,7 +1442,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ScanChainMixedLengths) {
 // buffers were at addresses that disagreed with key data ordering.
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ScanRangeReversedPointerOrder) {
   unodb::test::tree_verifier<TypeParam> verifier;
-  const auto val = unodb::test::test_values[0];
+  const auto val = unodb::test_data::test_values[0];
 
   // Insert 3 keys: 0x01, 0x02, 0x03.
   std::array<std::byte, 1> buf_a{std::byte{0x01}};
@@ -1654,7 +1486,7 @@ UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, ScanRangeReversedPointerOrder) {
 UNODB_TYPED_TEST(ARTKeyViewCorrectnessTest, DispatchByteCollision) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
-  constexpr auto val = unodb::test::test_value_1;
+  constexpr auto val = unodb::test_data::test_value_1;
 
   // make_key(0x42, 1) and make_key(0x42, 2) share 8 bytes — exercises
   // the chain-creation path for keys with long shared prefixes.

--- a/test/test_art_key_view_full_chain.cpp
+++ b/test/test_art_key_view_full_chain.cpp
@@ -21,7 +21,6 @@
 #include <array>
 #include <cstddef>  // IWYU pragma: keep
 #include <cstdint>
-#include <limits>
 #include <random>
 #include <stdexcept>
 #include <tuple>
@@ -30,9 +29,21 @@
 #include <gtest/gtest.h>
 
 #include "art_common.hpp"
+#include "art_test_data.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
 #include "node_type.hpp"
+
+// Each `copy_key(make_*(enc, ...), buf)` region below is wrapped in a 26815
+// suppression.  MSVC's analyzer sees the `key_view` returned by the `make_*`
+// builder die at the end of the full expression and concludes the result
+// dangles; it does not model that `copy_key` copies those bytes into `buf` and
+// returns a view over `buf`, severing the dependency on its `kv` argument -
+// which is exactly why `kv` is left unannotated while `buf` carries
+// UNODB_DETAIL_LIFETIMEBOUND.  The suppressions are per-region rather than
+// file-scope so that a genuine dangling `key_view` elsewhere in this file -
+// the one place where such views most often alias a reused encoder - is still
+// diagnosed.
 
 namespace {
 
@@ -60,15 +71,10 @@ UNODB_TYPED_TEST_SUITE(ARTKeyViewFullChainTest, ARTTypes)
 /// Unit test of correct rejection of a key which is too large to be
 /// stored in the tree.
 UNODB_TYPED_TEST(ARTKeyViewFullChainTest, TooLongKey) {
-  constexpr std::byte fake_val{0x00};
-  const unodb::key_view too_long{
-      &fake_val,
-      static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) +
-          1U};
-
   unodb::test::tree_verifier<TypeParam> verifier;
 
-  UNODB_ASSERT_THROW(std::ignore = verifier.get_db().insert(too_long, {}),
+  UNODB_ASSERT_THROW(std::ignore = verifier.get_db().insert(
+                         unodb::test_data::too_long_key_view(), {}),
                      std::length_error);
 
   verifier.assert_empty();
@@ -96,14 +102,8 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, EncodedTextKeys) {
   unodb::test::tree_verifier<TypeParam> verifier;
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
-  verifier.insert(enc.reset().encode_text("").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("a").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("abba").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("banana").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("camel").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("yellow").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("ostritch").get_key_view(), val);
-  verifier.insert(enc.reset().encode_text("zebra").get_key_view(), val);
+  for (const auto word : unodb::test_data::encoded_text_keys)
+    verifier.insert(enc.reset().encode_text(word).get_key_view(), val);
   verifier.check_present_values();
 }
 
@@ -139,31 +139,13 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, EncodedTextKeys) {
 //     6e. Multi-level chain — 17-byte keys, 2 chain levels
 // ===================================================================
 
-// Helper: encode a 9-byte key (uint8 + uint64).
-// Same tag byte → 8 shared bytes when uint64 values are small.
-inline unodb::key_view make_key(unodb::key_encoder& enc, std::uint8_t tag,
-                                std::uint64_t v) {
-  return enc.reset().encode(tag).encode(v).get_key_view();
-}
-
-// Helper: encode a 1-byte key (uint8 only).
-// Diverges at byte 0 from any key with a different first byte.
-// Used in cascade tests where we need direct-leaf children of the root
-// alongside a chain subtree.
-[[maybe_unused]] inline unodb::key_view make_short_key(unodb::key_encoder& enc,
-                                                       std::uint8_t tag) {
-  return enc.reset().encode(tag).get_key_view();
-}
-
-// Helper: encode a 10-byte key (uint8 + uint64 + uint8).
-// When used with the same tag and v as make_key, the 9-byte key is a
-// prefix of this 10-byte key — which ART does not support.  Use
-// different v values to avoid prefix relationships.
-// Both lengths (9 and 10) exceed key_prefix_capacity + 1 = 8.
-inline unodb::key_view make_long_key(unodb::key_encoder& enc, std::uint8_t tag,
-                                     std::uint64_t v, std::uint8_t suffix) {
-  return enc.reset().encode(tag).encode(v).encode(suffix).get_key_view();
-}
+// Key construction helpers shared with the other test executables; see
+// art_test_data.hpp for the encoded key shapes.
+using unodb::test_data::make_key;
+using unodb::test_data::make_key_17;
+using unodb::test_data::make_key_17_byte10;
+using unodb::test_data::make_long_key;
+using unodb::test_data::make_short_key;
 
 // -------------------------------------------------------------------
 // Group 0: Original bug reproduction tests
@@ -244,14 +226,8 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MultiLevelChain) {
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
   // 17 bytes: 0xAA × 16, then 0x01 vs 0x02.
-  auto make17 = [&](std::uint8_t last) {
-    enc.reset();
-    for (unsigned i = 0; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
-    enc.encode(last);
-    return enc.get_key_view();
-  };
-  verifier.insert(make17(0x01), val);
-  verifier.insert(make17(0x02), val);
+  verifier.insert(make_key_17(enc, 0x01), val);
+  verifier.insert(make_key_17(enc, 0x02), val);
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
   // 2 chain I4s (depth 0→8, 8→16) + bottom I4 (2 children) + 2 leaves
@@ -268,19 +244,11 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest,
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make17 = [&](std::uint8_t byte10, std::uint8_t last) {
-    enc.reset();
-    for (unsigned i = 0; i < 10; ++i) enc.encode(std::uint8_t{0xAA});
-    enc.encode(byte10);
-    for (unsigned i = 11; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
-    enc.encode(last);
-    return enc.get_key_view();
-  };
   // A and B share 16 bytes (byte10=0xAA), differ at byte 16.
-  verifier.insert(make17(0xAA, 0x01), val);
-  verifier.insert(make17(0xAA, 0x02), val);
+  verifier.insert(make_key_17_byte10(enc, 0xAA, 0x01), val);
+  verifier.insert(make_key_17_byte10(enc, 0xAA, 0x02), val);
   // C diverges at byte 10 — splits the second chain node.
-  verifier.insert(make17(0xBB, 0x03), val);
+  verifier.insert(make_key_17_byte10(enc, 0xBB, 0x03), val);
   verifier.check_present_values();
 #ifdef UNODB_DETAIL_WITH_STATS
   // chain I4 (bytes 0-7) + split I4 (at byte 10) + chain I4 (bytes 11-15)
@@ -632,6 +600,13 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CompoundKeyGetMissing) {
 
 #ifdef UNODB_DETAIL_WITH_STATS
 
+// Key helpers used only by the stats tests below.
+using unodb::test_data::copy_key;
+using unodb::test_data::make_key_11;
+using unodb::test_data::make_key_18;
+using unodb::test_data::make_key_26;
+using unodb::test_data::make_key_34;
+
 // ===================================================================
 // Group 6: Stats verification — node counts at intermediate states
 //
@@ -899,21 +874,15 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MultiLevelChainRemoveAll) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make17 = [&](std::uint8_t last) {
-    enc.reset();
-    for (unsigned i = 0; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
-    enc.encode(last);
-    return enc.get_key_view();
-  };
-  verifier.insert(make17(0x01), val);
-  verifier.insert(make17(0x02), val);
+  verifier.insert(make_key_17(enc, 0x01), val);
+  verifier.insert(make_key_17(enc, 0x02), val);
   verifier.assert_node_counts({TestFixture::leaf_count(2), 3, 0, 0, 0});
 
-  verifier.remove(make17(0x01));
+  verifier.remove(make_key_17(enc, 0x01));
   // Keyless leaf prevents collapse.  Three chain I4s remain.
   verifier.assert_node_counts({TestFixture::leaf_count(1), 3, 0, 0, 0});
 
-  verifier.remove(make17(0x02));
+  verifier.remove(make_key_17(enc, 0x02));
   verifier.assert_empty();
 }
 
@@ -1019,26 +988,20 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MultiLevelChainFatBottom) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make17 = [&](std::uint8_t last) {
-    enc.reset();
-    for (unsigned i = 0; i < 16; ++i) enc.encode(std::uint8_t{0xAA});
-    enc.encode(last);
-    return enc.get_key_view();
-  };
-
-  for (std::uint8_t i = 1; i <= 5; ++i) verifier.insert(make17(i), val);
+  for (std::uint8_t i = 1; i <= 5; ++i)
+    verifier.insert(make_key_17(enc, i), val);
   verifier.check_present_values();
   // 2 chain-I4s + bottom I16(5) + 5 leaves
   verifier.assert_node_counts({TestFixture::leaf_count(5), 2, 1, 0, 0});
   verifier.assert_growing_inodes({3, 1, 0, 0});
 
   // Remove 1 → I16 at min_size → shrink to I4.
-  verifier.remove(make17(1));
+  verifier.remove(make_key_17(enc, 1));
   verifier.assert_node_counts({TestFixture::leaf_count(4), 3, 0, 0, 0});
   verifier.assert_shrinking_inodes({0, 1, 0, 0});
 
   // Remove remaining → chains collapse.
-  for (std::uint8_t i = 2; i <= 5; ++i) verifier.remove(make17(i));
+  for (std::uint8_t i = 2; i <= 5; ++i) verifier.remove(make_key_17(enc, i));
   verifier.assert_empty();
 }
 
@@ -1060,19 +1023,11 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MidLevelInodeGrowth) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make18 = [&](std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(std::uint64_t{0})
-        .encode(bottom)
-        .get_key_view();
-  };
-
   // 5 mid groups × 2 bottom keys = 10 keys.
   // Mid-inode at depth 8 grows to I16(5).
   for (std::uint8_t m = 1; m <= 5; ++m)
-    for (std::uint8_t b = 1; b <= 2; ++b) verifier.insert(make18(m, b), val);
+    for (std::uint8_t b = 1; b <= 2; ++b)
+      verifier.insert(make_key_18(enc, m, b), val);
   verifier.check_present_values();
   // chain(0) → mid-I16(5) → 5×(chain(9) → bottom-I4(2) → 2 leaves)
   // I4: 1 top-chain + 5 depth-9-chains + 5 bottoms = 11
@@ -1085,24 +1040,16 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, MidLevelInodeShrink) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make18 = [&](std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(std::uint64_t{0})
-        .encode(bottom)
-        .get_key_view();
-  };
-
   // 5 mid groups × 2 bottom keys = 10 keys → mid I16(5).
   for (std::uint8_t m = 1; m <= 5; ++m)
-    for (std::uint8_t b = 1; b <= 2; ++b) verifier.insert(make18(m, b), val);
+    for (std::uint8_t b = 1; b <= 2; ++b)
+      verifier.insert(make_key_18(enc, m, b), val);
 
   // Remove both keys for mid=1 → bottom-I4(2) collapses (I4 shrink),
   // chain(9) collapses (I4 shrink), mid-I16(5) at min_size → I4(4)
   // (I16 shrink).
-  verifier.remove(make18(1, 1));
-  verifier.remove(make18(1, 2));
+  verifier.remove(make_key_18(enc, 1, 1));
+  verifier.remove(make_key_18(enc, 1, 2));
   verifier.check_present_values();
   // chain(0) → mid-I4(4) → 4×(chain(9) → bottom-I4(2) → 2 leaves)
   // I4: 1 top-chain + 4 depth-9-chains + 4 bottoms + 1 mid = 10
@@ -1171,36 +1118,27 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1CollapseToLeaf) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
-
   // A and B share tag + 8 bytes → chain at depth 0, chain at depth 8.
   // C has different tag → sibling at root.
-  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
-  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
-  verifier.insert(make18(0x02, 0x00, 0x01), val);  // C
+  verifier.insert(make_key_11(enc, 0x01, 0x01), val);  // A
+  verifier.insert(make_key_11(enc, 0x01, 0x02), val);  // B
+  verifier.insert(make_key_11(enc, 0x02, 0x01), val);  // C
   verifier.check_present_values();
 
   // Remove B: bottom I4(2→1), chain extends.
-  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
   verifier.check_present_values();
 
   // Remove A: chain cut (CD=1). Root I4(2→1).
   // Surviving child is chain-I4 with 7-byte prefix.  Merge would be
   // 0 + 1 + 7 = 8 > 7 → prefix overflow, no collapse.
   // Tree: root-I4(1) → chain-I4 → leaf(C).
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
   verifier.assert_node_counts({TestFixture::leaf_count(1), 2, 0, 0, 0});
 
   // Remove C: tree empty.
-  verifier.remove(make18(0x02, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x02, 0x01));
   verifier.assert_empty();
 }
 
@@ -1248,31 +1186,22 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1CollapseToInode) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
-
   // A,B share tag=0x01 + 8 bytes → depth-1 chain → I4(2: A, B).
   // D,E have tag=0x02 → I4(2: D, E) subtree.
   // Root: I4(2: 0x01→chain→chain→I4(A,B), 0x02→chain→I4(D,E))
-  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
-  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
-  verifier.insert(make18(0x02, 0x00, 0x01), val);  // D
-  verifier.insert(make18(0x02, 0x00, 0x02), val);  // E
+  verifier.insert(make_key_11(enc, 0x01, 0x01), val);  // A
+  verifier.insert(make_key_11(enc, 0x01, 0x02), val);  // B
+  verifier.insert(make_key_11(enc, 0x02, 0x01), val);  // D
+  verifier.insert(make_key_11(enc, 0x02, 0x02), val);  // E
   verifier.check_present_values();
 
   // Remove B: bottom I4(2→1) under tag=0x01, chain extends.
-  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
   verifier.check_present_values();
 
   // Remove A: chain cut (CD=1). Root I4(2→1) collapses.
   // Remaining child is the tag=0x02 subtree — prefix merge needed.
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
 }
 
@@ -1282,26 +1211,17 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1RemoveFromI4) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
-
   // 3 tag groups: 0x01 (chain target), 0x02, 0x03.
   // Root: I4(3: chain→...A, leaf(D), leaf(E))
-  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
-  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
-  verifier.insert(make18(0x02, 0x00, 0x01), val);  // D
-  verifier.insert(make18(0x03, 0x00, 0x01), val);  // E
+  verifier.insert(make_key_11(enc, 0x01, 0x01), val);  // A
+  verifier.insert(make_key_11(enc, 0x01, 0x02), val);  // B
+  verifier.insert(make_key_11(enc, 0x02, 0x01), val);  // D
+  verifier.insert(make_key_11(enc, 0x03, 0x01), val);  // E
   verifier.check_present_values();
 
   // Remove B, then A: chain cut from I4(3→2).
-  verifier.remove(make18(0x01, 0x00, 0x02));
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
 }
 
@@ -1314,18 +1234,9 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest,
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
-
-  // A,B: tag=0x01, 18-byte keys → depth-1 chain → I4(2: A, B).
-  verifier.insert(make18(0x01, 0x00, 0x01), val);  // A
-  verifier.insert(make18(0x01, 0x00, 0x02), val);  // B
+  // A,B: tag=0x01, 11-byte keys → depth-1 chain → I4(2: A, B).
+  verifier.insert(make_key_11(enc, 0x01, 0x01), val);  // A
+  verifier.insert(make_key_11(enc, 0x01, 0x02), val);  // B
   // C,D: tag=0x02, 2-byte keys → I4(2: C, D) with empty prefix.
   verifier.insert(enc.reset()
                       .encode(std::uint8_t{0x02})
@@ -1340,13 +1251,13 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest,
   verifier.check_present_values();
 
   // Remove B: bottom I4(2→1) under tag=0x01, chain extends.
-  verifier.remove(make18(0x01, 0x00, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
   verifier.check_present_values();
 
   // Remove A: chain cut (CD=1). Root I4(2→1) collapses.
   // Remaining child is I4(C,D) with empty prefix.
   // Merge: root prefix(0) + dispatch(0x02) + child prefix(0) = 1 ≤ 7.
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
 }
 
@@ -1358,25 +1269,15 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD2CollapseToLeaf) {
 
   // 26-byte keys: tag + uint64 + uint64 + uint64 + uint8.
   // Two keys sharing 25 bytes → 3 chain levels (depth 0,8,16).
-  auto make26 = [&](std::uint8_t tag, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(std::uint64_t{0})
-        .encode(bottom)
-        .get_key_view();
-  };
-
-  verifier.insert(make26(0x01, 0x01), val);  // A
-  verifier.insert(make26(0x01, 0x02), val);  // B
-  verifier.insert(make26(0x02, 0x01), val);  // sibling
+  verifier.insert(make_key_26(enc, 0x01, 0x01), val);  // A
+  verifier.insert(make_key_26(enc, 0x01, 0x02), val);  // B
+  verifier.insert(make_key_26(enc, 0x02, 0x01), val);  // sibling
   verifier.check_present_values();
 
   // Remove B → chain extends. Remove A → CD=2 chain cut.
-  verifier.remove(make26(0x01, 0x02));
+  verifier.remove(make_key_26(enc, 0x01, 0x02));
   verifier.check_present_values();
-  verifier.remove(make26(0x01, 0x01));
+  verifier.remove(make_key_26(enc, 0x01, 0x01));
   verifier.check_present_values();
 
   // Sibling subtree remains: chain(depth 0)→chain(depth 8)→chain(depth 16)
@@ -1385,7 +1286,7 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD2CollapseToLeaf) {
   // Prefix overflow prevents collapse at each level.
 
   // Remove sibling → empty.
-  verifier.remove(make26(0x02, 0x01));
+  verifier.remove(make_key_26(enc, 0x02, 0x01));
   verifier.assert_empty();
 }
 
@@ -1426,33 +1327,24 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1PrefixOverflow) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
-
   // tag=0x01: 2 keys sharing 10 bytes → CD=1 chain.
   // tag=0x02: 2 keys → chain with 7-byte prefix.
   // Root I4 has empty prefix. 0x02 child has 7-byte prefix.
   // Collapse: 0 + 1 + 7 = 8 → overflow.
-  verifier.insert(make18(0x01, 0x00, 0x01), val);
-  verifier.insert(make18(0x01, 0x00, 0x02), val);
-  verifier.insert(make18(0x02, 0x00, 0x01), val);
-  verifier.insert(make18(0x02, 0x00, 0x02), val);
+  verifier.insert(make_key_11(enc, 0x01, 0x01), val);
+  verifier.insert(make_key_11(enc, 0x01, 0x02), val);
+  verifier.insert(make_key_11(enc, 0x02, 0x01), val);
+  verifier.insert(make_key_11(enc, 0x02, 0x02), val);
   verifier.check_present_values();
 
   // Remove both under tag=0x01 → CD=1 chain cut.
-  verifier.remove(make18(0x01, 0x00, 0x02));
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
 
   // tag=0x02 keys still accessible.
-  verifier.remove(make18(0x02, 0x00, 0x01));
-  verifier.remove(make18(0x02, 0x00, 0x02));
+  verifier.remove(make_key_11(enc, 0x02, 0x01));
+  verifier.remove(make_key_11(enc, 0x02, 0x02));
   verifier.assert_empty();
 }
 
@@ -1462,25 +1354,16 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1ShrinkI16) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
-
   // 5 tag groups → I16(5) at root level (after chain at depth 0).
   // Under tag=0x01: 2 keys → CD=1 chain.
   for (std::uint8_t t = 1; t <= 5; ++t)
     for (std::uint8_t b = 1; b <= 2; ++b)
-      verifier.insert(make18(t, 0x00, b), val);
+      verifier.insert(make_key_11(enc, t, b), val);
   verifier.check_present_values();
 
   // Remove both under tag=0x01 → CD=1 chain cut from I16(5→4) → I4.
-  verifier.remove(make18(0x01, 0x00, 0x02));
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
   // 8 leaves, 4 tag groups each with chain(depth 0)→chain(depth 8)→I4(2).
   // Top-level I4(4) + 4×(chain + bottom-I4) = 1 + 8 = 9 I4s.
@@ -1494,24 +1377,15 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1ShrinkI48) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
-
   // 17 tag groups → I48(17).
   for (std::uint8_t t = 1; t <= 17; ++t)
     for (std::uint8_t b = 1; b <= 2; ++b)
-      verifier.insert(make18(t, 0x00, b), val);
+      verifier.insert(make_key_11(enc, t, b), val);
   verifier.check_present_values();
 
   // Remove both under tag=0x01 → CD=1 chain cut from I48(17→16) → I16.
-  verifier.remove(make18(0x01, 0x00, 0x02));
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
   // 32 leaves, 16 tag groups each with chain→chain→I4(2).
   // Top-level I16(16) + 16×(chain + bottom-I4) = 0 + 32 = 32 I4s.
@@ -1525,24 +1399,15 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ChainCutCD1ShrinkI256) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make18 = [&](std::uint8_t tag, std::uint8_t mid, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(mid)
-        .encode(bottom)
-        .get_key_view();
-  };
-
   // 49 tag groups → I256(49).
   for (std::uint8_t t = 1; t <= 49; ++t)
     for (std::uint8_t b = 1; b <= 2; ++b)
-      verifier.insert(make18(t, 0x00, b), val);
+      verifier.insert(make_key_11(enc, t, b), val);
   verifier.check_present_values();
 
   // Remove both under tag=0x01 → CD=1 chain cut from I256(49→48) → I48.
-  verifier.remove(make18(0x01, 0x00, 0x02));
-  verifier.remove(make18(0x01, 0x00, 0x01));
+  verifier.remove(make_key_11(enc, 0x01, 0x02));
+  verifier.remove(make_key_11(enc, 0x01, 0x01));
   verifier.check_present_values();
   // 96 leaves, 48 tag groups each with chain→chain→I4(2).
   // Top-level I48(48) + 48×(chain + bottom-I4) = 0 + 96 = 96 I4s.
@@ -1572,12 +1437,10 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, KeylessLeafNoCollapseGuard) {
   // Two 1-byte keys with different dispatch bytes.
   std::array<std::byte, 1> buf_a{};
   std::array<std::byte, 1> buf_b{};
-  auto kv = enc.reset().encode(std::uint8_t{0x01}).get_key_view();
-  std::ignore = std::ranges::copy(kv, buf_a.begin());
-  kv = enc.reset().encode(std::uint8_t{0x02}).get_key_view();
-  std::ignore = std::ranges::copy(kv, buf_b.begin());
-  const auto key_a = unodb::key_view{buf_a.data(), buf_a.size()};
-  const auto key_b = unodb::key_view{buf_b.data(), buf_b.size()};
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26815)
+  const auto key_a = copy_key(make_short_key(enc, 0x01), buf_a);
+  const auto key_b = copy_key(make_short_key(enc, 0x02), buf_b);
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   verifier.insert(key_a, val);
   verifier.insert(key_b, val);
@@ -1612,24 +1475,11 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, CollapseToInodeAllowed) {
   std::array<std::byte, 9> buf_a{};
   std::array<std::byte, 9> buf_b{};
   std::array<std::byte, 9> buf_c{};
-  auto kv = enc.reset()
-                .encode(std::uint8_t{0x01})
-                .encode(std::uint64_t{0})
-                .get_key_view();
-  std::ignore = std::ranges::copy(kv, buf_a.begin());
-  kv = enc.reset()
-           .encode(std::uint8_t{0x02})
-           .encode(std::uint64_t{0})
-           .get_key_view();
-  std::ignore = std::ranges::copy(kv, buf_b.begin());
-  kv = enc.reset()
-           .encode(std::uint8_t{0x02})
-           .encode(std::uint64_t{1})
-           .get_key_view();
-  std::ignore = std::ranges::copy(kv, buf_c.begin());
-  const auto key_a = unodb::key_view{buf_a.data(), buf_a.size()};
-  const auto key_b = unodb::key_view{buf_b.data(), buf_b.size()};
-  const auto key_c = unodb::key_view{buf_c.data(), buf_c.size()};
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26815)
+  const auto key_a = copy_key(make_key(enc, 0x01, 0), buf_a);
+  const auto key_b = copy_key(make_key(enc, 0x02, 0), buf_b);
+  const auto key_c = copy_key(make_key(enc, 0x02, 1), buf_c);
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   verifier.insert(key_a, val);
   verifier.insert(key_b, val);
@@ -1662,29 +1512,19 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ConcurrentTestTree26Byte) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  auto make26 = [&](std::uint8_t tag, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(std::uint64_t{0x4242424242424242ULL})
-        .encode(std::uint64_t{0})
-        .encode(std::uint64_t{0})
-        .encode(bottom)
-        .get_key_view();
-  };
-
-  verifier.insert(make26(0x10, 0x01), val);  // A
-  verifier.insert(make26(0x10, 0x02), val);  // B
-  verifier.insert(make26(0x20, 0x01), val);  // sib
+  verifier.insert(make_key_26(enc, 0x10, 0x01), val);  // A
+  verifier.insert(make_key_26(enc, 0x10, 0x02), val);  // B
+  verifier.insert(make_key_26(enc, 0x20, 0x01), val);  // sib
   verifier.check_present_values();
 
-  verifier.remove(make26(0x10, 0x02));  // remove B
+  verifier.remove(make_key_26(enc, 0x10, 0x02));  // remove B
   verifier.check_present_values();
 
-  verifier.remove(make26(0x10, 0x01));  // remove A (chain cut)
+  verifier.remove(make_key_26(enc, 0x10, 0x01));  // remove A (chain cut)
   verifier.check_present_values();
 
   // Insert a new key at root level (what CT1's T2 does).
-  verifier.insert(make26(0x30, 0x01), val);
+  verifier.insert(make_key_26(enc, 0x30, 0x01), val);
   verifier.check_present_values();
 }
 
@@ -1695,34 +1535,23 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, ConcurrentTestTree34Byte) {
   unodb::key_encoder enc;
   constexpr auto val = unodb::test::get_test_value<TypeParam>(0);
 
-  constexpr auto X = std::uint64_t{0x4242424242424242ULL};
-  constexpr auto Z = std::uint64_t{0x4343434343434343ULL};
+  constexpr auto X = unodb::test_data::chain_key_filler;
+  constexpr auto Z = unodb::test_data::chain_key_filler_alt;
 
-  auto make34 = [&](std::uint8_t tag, std::uint64_t v1, std::uint8_t bottom) {
-    return enc.reset()
-        .encode(tag)
-        .encode(v1)
-        .encode(X)
-        .encode(X)
-        .encode(X)
-        .encode(bottom)
-        .get_key_view();
-  };
-
-  verifier.insert(make34(0x10, X, 0x01), val);  // A
-  verifier.insert(make34(0x10, X, 0x02), val);  // B
-  verifier.insert(make34(0x20, X, 0x01), val);  // sib
+  verifier.insert(make_key_34(enc, 0x10, X, 0x01), val);  // A
+  verifier.insert(make_key_34(enc, 0x10, X, 0x02), val);  // B
+  verifier.insert(make_key_34(enc, 0x20, X, 0x01), val);  // sib
   verifier.check_present_values();
 
-  verifier.remove(make34(0x10, X, 0x02));  // remove B
+  verifier.remove(make_key_34(enc, 0x10, X, 0x02));  // remove B
   verifier.check_present_values();
 
   // Insert T2's key (diverges at chain[0] level, different v1).
-  verifier.insert(make34(0x10, Z, 0x01), val);
+  verifier.insert(make_key_34(enc, 0x10, Z, 0x01), val);
   verifier.check_present_values();
 
   // Remove A (chain cut with T2's key already in tree).
-  verifier.remove(make34(0x10, X, 0x01));
+  verifier.remove(make_key_34(enc, 0x10, X, 0x01));
   verifier.check_present_values();
 }
 
@@ -1812,19 +1641,10 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureTwoChainKeys) {
 
   std::array<std::byte, 9> buf_a{};
   std::array<std::byte, 9> buf_b{};
-  auto kv = enc.reset()
-                .encode(std::uint8_t{0x01})
-                .encode(std::uint64_t{100})
-                .get_key_view();
-  std::ignore = std::ranges::copy(kv, buf_a.begin());
-  kv = enc.reset()
-           .encode(std::uint8_t{0x01})
-           .encode(std::uint64_t{200})
-           .get_key_view();
-  std::ignore = std::ranges::copy(kv, buf_b.begin());
-
-  const auto key_a = unodb::key_view{buf_a.data(), buf_a.size()};
-  const auto key_b = unodb::key_view{buf_b.data(), buf_b.size()};
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26815)
+  const auto key_a = copy_key(make_key(enc, 0x01, 100), buf_a);
+  const auto key_b = copy_key(make_key(enc, 0x01, 200), buf_b);
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   std::ignore = db.insert(key_a, val);
   std::ignore = db.insert(key_b, val);
@@ -1845,16 +1665,11 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureWideNode) {
   std::array<std::byte, 1> ba{};
   std::array<std::byte, 1> bb{};
   std::array<std::byte, 1> bc{};
-  auto kv = enc.reset().encode(std::uint8_t{0x10}).get_key_view();
-  std::ignore = std::ranges::copy(kv, ba.begin());
-  kv = enc.reset().encode(std::uint8_t{0x20}).get_key_view();
-  std::ignore = std::ranges::copy(kv, bb.begin());
-  kv = enc.reset().encode(std::uint8_t{0x30}).get_key_view();
-  std::ignore = std::ranges::copy(kv, bc.begin());
-
-  const auto ka = unodb::key_view{ba.data(), ba.size()};
-  const auto kb = unodb::key_view{bb.data(), bb.size()};
-  const auto kc = unodb::key_view{bc.data(), bc.size()};
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26815)
+  const auto ka = copy_key(make_short_key(enc, 0x10), ba);
+  const auto kb = copy_key(make_short_key(enc, 0x20), bb);
+  const auto kc = copy_key(make_short_key(enc, 0x30), bc);
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   std::ignore = db.insert(ka, val);
   std::ignore = db.insert(kb, val);
@@ -1873,19 +1688,10 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureSecondInsertChain) {
 
   std::array<std::byte, 9> buf_a{};
   std::array<std::byte, 9> buf_b{};
-  auto kv = enc.reset()
-                .encode(std::uint8_t{0x01})
-                .encode(std::uint64_t{0})
-                .get_key_view();
-  std::ignore = std::ranges::copy(kv, buf_a.begin());
-  kv = enc.reset()
-           .encode(std::uint8_t{0x02})
-           .encode(std::uint64_t{0})
-           .get_key_view();
-  std::ignore = std::ranges::copy(kv, buf_b.begin());
-
-  const auto ka = unodb::key_view{buf_a.data(), buf_a.size()};
-  const auto kb = unodb::key_view{buf_b.data(), buf_b.size()};
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26815)
+  const auto ka = copy_key(make_key(enc, 0x01, 0), buf_a);
+  const auto kb = copy_key(make_key(enc, 0x02, 0), buf_b);
+  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   std::ignore = db.insert(ka, val);
   std::ignore = db.insert(kb, val);
@@ -1910,7 +1716,7 @@ UNODB_TYPED_TEST(ARTKeyViewFullChainTest, StackStructureFullScan) {
   };
   auto make = [&](std::uint8_t tag, std::uint64_t v) {
     kh h;
-    auto k = enc.reset().encode(tag).encode(v).get_key_view();
+    const auto k = make_key(enc, tag, v);
     std::ignore = std::ranges::copy(k, h.buf.begin());
     h.len = k.size();
     UNODB_DETAIL_DISABLE_CLANG_21_WARNING("-Wnrvo")

--- a/test/test_art_oom.cpp
+++ b/test/test_art_oom.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include "art_common.hpp"
+#include "art_test_data.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
 #include "test_heap.hpp"
@@ -200,7 +201,7 @@ UNODB_TYPED_TEST(ARTOOMTest, SingleNodeTreeNonemptyValue) {
         verifier.assert_growing_inodes({0, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
       },
-      1, unodb::test::test_values[2],
+      1, unodb::test_data::test_values[2],
       [](unodb::test::tree_verifier<TypeParam>&
 #ifdef UNODB_DETAIL_WITH_STATS
              verifier
@@ -217,13 +218,13 @@ UNODB_TYPED_TEST(ARTOOMTest, ExpandLeafToNode4) {
   oom_insert_test<TypeParam>(
       3,
       [](unodb::test::tree_verifier<TypeParam>& verifier) {
-        verifier.insert(0, unodb::test::test_values[1]);
+        verifier.insert(0, unodb::test_data::test_values[1]);
 #ifdef UNODB_DETAIL_WITH_STATS
         verifier.assert_node_counts({1, 0, 0, 0, 0});
         verifier.assert_growing_inodes({0, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
       },
-      1, unodb::test::test_values[2],
+      1, unodb::test_data::test_values[2],
       [](unodb::test::tree_verifier<TypeParam>&
 #ifdef UNODB_DETAIL_WITH_STATS
              verifier
@@ -240,8 +241,8 @@ UNODB_TYPED_TEST(ARTOOMTest, TwoNode4) {
   oom_insert_test<TypeParam>(
       3,
       [](unodb::test::tree_verifier<TypeParam>& verifier) {
-        verifier.insert(1, unodb::test::test_values[0]);
-        verifier.insert(3, unodb::test::test_values[2]);
+        verifier.insert(1, unodb::test_data::test_values[0]);
+        verifier.insert(3, unodb::test_data::test_values[2]);
 #ifdef UNODB_DETAIL_WITH_STATS
         verifier.assert_growing_inodes({1, 0, 0, 0});
         verifier.assert_node_counts({2, 1, 0, 0, 0});
@@ -249,7 +250,7 @@ UNODB_TYPED_TEST(ARTOOMTest, TwoNode4) {
 #endif  // UNODB_DETAIL_WITH_STATS
       },
       // Insert a value that does not share full prefix with the current Node4
-      0xFF01, unodb::test::test_values[3],
+      0xFF01, unodb::test_data::test_values[3],
       [](unodb::test::tree_verifier<TypeParam>&
 #ifdef UNODB_DETAIL_WITH_STATS
              verifier
@@ -267,10 +268,10 @@ UNODB_TYPED_TEST(ARTOOMTest, DbInsertNodeRecursion) {
   oom_insert_test<TypeParam>(
       3,
       [](unodb::test::tree_verifier<TypeParam>& verifier) {
-        verifier.insert(1, unodb::test::test_values[0]);
-        verifier.insert(3, unodb::test::test_values[2]);
+        verifier.insert(1, unodb::test_data::test_values[0]);
+        verifier.insert(3, unodb::test_data::test_values[2]);
         // Insert a value that does not share full prefix with the current Node4
-        verifier.insert(0xFF0001, unodb::test::test_values[3]);
+        verifier.insert(0xFF0001, unodb::test_data::test_values[3]);
 #ifdef UNODB_DETAIL_WITH_STATS
         verifier.assert_node_counts({3, 2, 0, 0, 0});
         verifier.assert_growing_inodes({2, 0, 0, 0});
@@ -279,7 +280,7 @@ UNODB_TYPED_TEST(ARTOOMTest, DbInsertNodeRecursion) {
       },
       // Then insert a value that shares full prefix with the above node and
       // will ask for a recursive insertion there
-      0xFF0101, unodb::test::test_values[1],
+      0xFF0101, unodb::test_data::test_values[1],
       [](unodb::test::tree_verifier<TypeParam>&
 #ifdef UNODB_DETAIL_WITH_STATS
              verifier
@@ -302,7 +303,7 @@ UNODB_TYPED_TEST(ARTOOMTest, Node16) {
         verifier.assert_growing_inodes({1, 0, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
       },
-      5, unodb::test::test_values[0],
+      5, unodb::test_data::test_values[0],
       [](unodb::test::tree_verifier<TypeParam>&
 #ifdef UNODB_DETAIL_WITH_STATS
              verifier
@@ -327,7 +328,7 @@ UNODB_TYPED_TEST(ARTOOMTest, Node16KeyPrefixSplit) {
 #endif  // UNODB_DETAIL_WITH_STATS
       },
       // Insert a value that does share full prefix with the current Node16
-      0x1020, unodb::test::test_values[0],
+      0x1020, unodb::test_data::test_values[0],
       [](unodb::test::tree_verifier<TypeParam>&
 #ifdef UNODB_DETAIL_WITH_STATS
              verifier
@@ -351,7 +352,7 @@ UNODB_TYPED_TEST(ARTOOMTest, Node48) {
         verifier.assert_growing_inodes({1, 1, 0, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
       },
-      16, unodb::test::test_values[0],
+      16, unodb::test_data::test_values[0],
       [](unodb::test::tree_verifier<TypeParam>&
 #ifdef UNODB_DETAIL_WITH_STATS
              verifier
@@ -376,7 +377,7 @@ UNODB_TYPED_TEST(ARTOOMTest, Node48KeyPrefixSplit) {
 #endif  // UNODB_DETAIL_WITH_STATS
       },
       // Insert a value that does share full prefix with the current Node48
-      0x100020, unodb::test::test_values[0],
+      0x100020, unodb::test_data::test_values[0],
       [](unodb::test::tree_verifier<TypeParam>&
 #ifdef UNODB_DETAIL_WITH_STATS
              verifier
@@ -400,7 +401,7 @@ UNODB_TYPED_TEST(ARTOOMTest, Node256) {
         verifier.assert_growing_inodes({1, 1, 1, 0});
 #endif  // UNODB_DETAIL_WITH_STATS
       },
-      49, unodb::test::test_values[0],
+      49, unodb::test_data::test_values[0],
       [](unodb::test::tree_verifier<TypeParam>&
 #ifdef UNODB_DETAIL_WITH_STATS
              verifier
@@ -425,7 +426,7 @@ UNODB_TYPED_TEST(ARTOOMTest, Node256KeyPrefixSplit) {
 #endif  // UNODB_DETAIL_WITH_STATS
       },
       // Insert a value that does share full prefix with the current Node48
-      0x100020, unodb::test::test_values[0],
+      0x100020, unodb::test_data::test_values[0],
       [](unodb::test::tree_verifier<TypeParam>&
 #ifdef UNODB_DETAIL_WITH_STATS
              verifier
@@ -574,12 +575,10 @@ UNODB_TYPED_TEST(ARTKeyViewOOMTest, BuildChainNonfull) {
   unodb::key_encoder enc2;
   unodb::key_encoder enc3;
   unodb::key_encoder enc_long;
-  const auto short1 = enc1.encode(std::uint8_t{1}).get_key_view();
-  const auto short2 = enc2.encode(std::uint8_t{2}).get_key_view();
-  const auto short3 = enc3.encode(std::uint8_t{3}).get_key_view();
-  const auto long_key = enc_long.encode(std::uint8_t{0x10})
-                            .encode(std::uint64_t{1})
-                            .get_key_view();
+  const auto short1 = unodb::test_data::make_short_key(enc1, 1);
+  const auto short2 = unodb::test_data::make_short_key(enc2, 2);
+  const auto short3 = unodb::test_data::make_short_key(enc3, 3);
+  const auto long_key = unodb::test_data::make_key(enc_long, 0x10, 1);
 
   oom_test<TypeParam>(
       chain_oom_limit<TypeParam>(1),
@@ -613,13 +612,11 @@ UNODB_TYPED_TEST(ARTKeyViewOOMTest, BuildChainGrow) {
   unodb::key_encoder enc3;
   unodb::key_encoder enc4;
   unodb::key_encoder enc_long;
-  const auto short1 = enc1.encode(std::uint8_t{1}).get_key_view();
-  const auto short2 = enc2.encode(std::uint8_t{2}).get_key_view();
-  const auto short3 = enc3.encode(std::uint8_t{3}).get_key_view();
-  const auto short4 = enc4.encode(std::uint8_t{4}).get_key_view();
-  const auto long_key = enc_long.encode(std::uint8_t{0x10})
-                            .encode(std::uint64_t{1})
-                            .get_key_view();
+  const auto short1 = unodb::test_data::make_short_key(enc1, 1);
+  const auto short2 = unodb::test_data::make_short_key(enc2, 2);
+  const auto short3 = unodb::test_data::make_short_key(enc3, 3);
+  const auto short4 = unodb::test_data::make_short_key(enc4, 4);
+  const auto long_key = unodb::test_data::make_key(enc_long, 0x10, 1);
 
   oom_test<TypeParam>(
       chain_oom_limit<TypeParam>(2),
@@ -651,13 +648,11 @@ UNODB_TYPED_TEST(ARTKeyViewOOMTest, BuildChainPrefixSplit) {
 
   unodb::key_encoder enc1;
   unodb::key_encoder enc2;
-  const auto key1 =
-      enc1.encode(std::uint8_t{0x42}).encode(std::uint64_t{1}).get_key_view();
+  const auto key1 = unodb::test_data::make_key(enc1, 0x42, 1);
   // uint64 value with high bit set → first encoded byte is 0x80, diverges
   // at byte 1 from key1's 0x00.
-  const auto key2 = enc2.encode(std::uint8_t{0x42})
-                        .encode(std::uint64_t{0x8000000000000001ULL})
-                        .get_key_view();
+  const auto key2 =
+      unodb::test_data::make_key(enc2, 0x42, 0x8000000000000001ULL);
 
   oom_test<TypeParam>(
       chain_oom_limit<TypeParam>(2),
@@ -685,9 +680,9 @@ UNODB_TYPED_TEST(ARTKeyViewOOMTest, BuildChainMultiNode) {
   unodb::key_encoder enc2;
   unodb::key_encoder enc3;
   unodb::key_encoder enc_long;
-  const auto short1 = enc1.encode(std::uint8_t{1}).get_key_view();
-  const auto short2 = enc2.encode(std::uint8_t{2}).get_key_view();
-  const auto short3 = enc3.encode(std::uint8_t{3}).get_key_view();
+  const auto short1 = unodb::test_data::make_short_key(enc1, 1);
+  const auto short2 = unodb::test_data::make_short_key(enc2, 2);
+  const auto short3 = unodb::test_data::make_short_key(enc3, 3);
   const auto long_key = enc_long.encode(std::uint8_t{0x10})
                             .encode(std::uint64_t{1})
                             .encode(std::uint64_t{2})
@@ -743,7 +738,7 @@ void bulk_load_oom_test(
 
 // Small tree (single leaf → one allocation)
 UNODB_TYPED_TEST(ARTOOMTest, BulkLoadSingleKey) {
-  constexpr auto val = unodb::test::test_values[0];
+  constexpr auto val = unodb::test_data::test_values[0];
   const std::vector<std::pair<std::uint64_t, unodb::value_view>> kv{{42, val}};
   bulk_load_oom_test<TypeParam>(5, kv);
 }

--- a/test/test_art_scan.cpp
+++ b/test/test_art_scan.cpp
@@ -19,6 +19,7 @@
 #include <gtest/gtest.h>
 
 #include "art_common.hpp"
+#include "art_test_data.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
 
@@ -31,13 +32,8 @@ class ARTScanTest : public ::testing::Test {
   using Test::Test;
 };
 
-// decode a uint64_t key.
-[[nodiscard]] std::uint64_t decode(unodb::key_view akey) noexcept {
-  unodb::key_decoder dec{akey};
-  std::uint64_t k;
-  dec.decode(k);
-  return k;
-}
+using unodb::test_data::decode;
+using unodb::test_data::test_values;
 
 // used with conditional compilation for debug.
 //
@@ -79,8 +75,7 @@ void do_scan_range_test(std::uint64_t from_key, std::uint64_t to_key,
   std::vector<std::pair<std::uint64_t, unodb::value_view>> expected{};
   if (from_key < to_key) {
     for (uint64_t i = 1; i < limit; i += 2) {
-      const auto val =
-          unodb::test::test_values[i % unodb::test::test_values.size()];
+      const auto val = test_values[i % test_values.size()];
       verifier.insert(i, val);
       if (i >= from_key && i < to_key) {
         expected.emplace_back(i, val);
@@ -89,8 +84,7 @@ void do_scan_range_test(std::uint64_t from_key, std::uint64_t to_key,
   } else {  // reverse scan
     for (auto i = static_cast<std::int64_t>(limit); i >= 0; i -= 2) {
       const auto j = static_cast<std::uint64_t>(i);
-      const auto val =
-          unodb::test::test_values[j % unodb::test::test_values.size()];
+      const auto val = test_values[j % test_values.size()];
       verifier.insert(j, val);
       if (j <= from_key && j > to_key) {
         expected.emplace_back(j, val);
@@ -209,7 +203,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanForwardEmptyTree) {
 UNODB_TYPED_TEST(ARTScanTest, scanForwardOneLeaf) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(0, test_values[0]);
   uint64_t n = 0;
   std::uint64_t visited_key{~0ULL};
   unodb::value_view visited_val{};
@@ -224,14 +218,13 @@ UNODB_TYPED_TEST(ARTScanTest, scanForwardOneLeaf) {
   db.scan(fn);
   UNODB_EXPECT_EQ(1, n);
   UNODB_EXPECT_EQ(visited_key, 0);
-  UNODB_EXPECT_TRUE(
-      std::ranges::equal(visited_val, unodb::test::test_values[0]));
+  UNODB_EXPECT_TRUE(std::ranges::equal(visited_val, test_values[0]));
 }
 
 UNODB_TYPED_TEST(ARTScanTest, scanFromForwardOneLeaf) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(0, test_values[0]);
   uint64_t n = 0;
   std::uint64_t visited_key{~0ULL};
   unodb::value_view visited_val{};
@@ -246,14 +239,13 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromForwardOneLeaf) {
   db.scan_from(0, fn);
   UNODB_EXPECT_EQ(1, n);
   UNODB_EXPECT_EQ(visited_key, 0);
-  UNODB_EXPECT_TRUE(
-      std::ranges::equal(visited_val, unodb::test::test_values[0]));
+  UNODB_EXPECT_TRUE(std::ranges::equal(visited_val, test_values[0]));
 }
 
 UNODB_TYPED_TEST(ARTScanTest, scanRangeForwardOneLeaf) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(0, test_values[0]);
   uint64_t n = 0;
   std::uint64_t visited_key{~0ULL};
   unodb::value_view visited_val{};
@@ -268,15 +260,14 @@ UNODB_TYPED_TEST(ARTScanTest, scanRangeForwardOneLeaf) {
   db.scan_range(0, 1, fn);
   UNODB_EXPECT_EQ(1, n);
   UNODB_EXPECT_EQ(visited_key, 0);
-  UNODB_EXPECT_TRUE(
-      std::ranges::equal(visited_val, unodb::test::test_values[0]));
+  UNODB_EXPECT_TRUE(std::ranges::equal(visited_val, test_values[0]));
 }
 
 UNODB_TYPED_TEST(ARTScanTest, scanForwardTwoLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
   uint64_t n = 0;
   std::vector<std::pair<std::uint64_t, unodb::value_view>> visited{};
   auto fn = [&n,
@@ -295,8 +286,8 @@ UNODB_TYPED_TEST(ARTScanTest, scanForwardTwoLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanFromForwardTwoLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
   uint64_t n = 0;
   std::vector<std::pair<std::uint64_t, unodb::value_view>> visited{};
   auto fn = [&n,
@@ -315,8 +306,8 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromForwardTwoLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanRangeForwardTwoLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
   uint64_t n = 0;
   std::vector<std::pair<std::uint64_t, unodb::value_view>> visited{};
   auto fn = [&n,
@@ -335,9 +326,9 @@ UNODB_TYPED_TEST(ARTScanTest, scanRangeForwardTwoLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanForwardThreeLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
-  verifier.insert(2, unodb::test::test_values[2]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
+  verifier.insert(2, test_values[2]);
   uint64_t n = 0;
   uint64_t expected = 0;
   const auto fn = [&n, &expected](
@@ -356,10 +347,10 @@ UNODB_TYPED_TEST(ARTScanTest, scanForwardThreeLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanForwardFourLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
-  verifier.insert(2, unodb::test::test_values[2]);
-  verifier.insert(3, unodb::test::test_values[3]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
+  verifier.insert(2, test_values[2]);
+  verifier.insert(3, test_values[3]);
   uint64_t n = 0;
   uint64_t expected = 0;
   const auto fn = [&n, &expected](
@@ -378,11 +369,11 @@ UNODB_TYPED_TEST(ARTScanTest, scanForwardFourLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanForwardFiveLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
-  verifier.insert(2, unodb::test::test_values[2]);
-  verifier.insert(3, unodb::test::test_values[3]);
-  verifier.insert(4, unodb::test::test_values[4]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
+  verifier.insert(2, test_values[2]);
+  verifier.insert(3, test_values[3]);
+  verifier.insert(4, test_values[4]);
   uint64_t n = 0;
   uint64_t expected = 0;
   const auto fn = [&n, &expected](
@@ -401,11 +392,11 @@ UNODB_TYPED_TEST(ARTScanTest, scanForwardFiveLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanForwardFiveLeavesHaltEarly) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
-  verifier.insert(2, unodb::test::test_values[2]);
-  verifier.insert(3, unodb::test::test_values[3]);
-  verifier.insert(4, unodb::test::test_values[4]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
+  verifier.insert(2, test_values[2]);
+  verifier.insert(3, test_values[3]);
+  verifier.insert(4, test_values[4]);
   uint64_t n = 0;
   const auto fn =
       [&n](const unodb::visitor<typename TypeParam::iterator>&) noexcept {
@@ -419,11 +410,11 @@ UNODB_TYPED_TEST(ARTScanTest, scanForwardFiveLeavesHaltEarly) {
 UNODB_TYPED_TEST(ARTScanTest, scanFromForwardFiveLeavesHaltEarly) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
-  verifier.insert(2, unodb::test::test_values[2]);
-  verifier.insert(3, unodb::test::test_values[3]);
-  verifier.insert(4, unodb::test::test_values[4]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
+  verifier.insert(2, test_values[2]);
+  verifier.insert(3, test_values[3]);
+  verifier.insert(4, test_values[4]);
   uint64_t n = 0;
   const auto fn =
       [&n](const unodb::visitor<typename TypeParam::iterator>&) noexcept {
@@ -437,11 +428,11 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromForwardFiveLeavesHaltEarly) {
 UNODB_TYPED_TEST(ARTScanTest, scanRangeForwardFiveLeavesHaltEarly) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
-  verifier.insert(2, unodb::test::test_values[2]);
-  verifier.insert(3, unodb::test::test_values[3]);
-  verifier.insert(4, unodb::test::test_values[4]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
+  verifier.insert(2, test_values[2]);
+  verifier.insert(3, test_values[3]);
+  verifier.insert(4, test_values[4]);
   uint64_t n = 0;
   const auto fn =
       [&n](const unodb::visitor<typename TypeParam::iterator>&) noexcept {
@@ -592,7 +583,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanReverseEmptyTree) {
 UNODB_TYPED_TEST(ARTScanTest, scanReverseOneLeaf) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(0, test_values[0]);
   uint64_t n = 0;
   std::uint64_t visited_key{~0ULL};
   unodb::value_view visited_val{};
@@ -607,14 +598,13 @@ UNODB_TYPED_TEST(ARTScanTest, scanReverseOneLeaf) {
   db.scan(fn, false /*fwd*/);
   UNODB_EXPECT_EQ(1, n);
   UNODB_EXPECT_EQ(visited_key, 0);
-  UNODB_EXPECT_TRUE(
-      std::ranges::equal(visited_val, unodb::test::test_values[0]));
+  UNODB_EXPECT_TRUE(std::ranges::equal(visited_val, test_values[0]));
 }
 
 UNODB_TYPED_TEST(ARTScanTest, scanFromReverseOneLeaf) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
+  verifier.insert(0, test_values[0]);
   uint64_t n = 0;
   std::uint64_t visited_key{~0ULL};
   unodb::value_view visited_val{};
@@ -629,14 +619,13 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromReverseOneLeaf) {
   db.scan_from(0, fn, false /*fwd*/);
   UNODB_EXPECT_EQ(1, n);
   UNODB_EXPECT_EQ(visited_key, 0);
-  UNODB_EXPECT_TRUE(
-      std::ranges::equal(visited_val, unodb::test::test_values[0]));
+  UNODB_EXPECT_TRUE(std::ranges::equal(visited_val, test_values[0]));
 }
 
 UNODB_TYPED_TEST(ARTScanTest, scanRangeReverseOneLeaf) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(1, unodb::test::test_values[0]);
+  verifier.insert(1, test_values[0]);
   uint64_t n = 0;
   std::uint64_t visited_key{~1ULL};
   unodb::value_view visited_val{};
@@ -651,15 +640,14 @@ UNODB_TYPED_TEST(ARTScanTest, scanRangeReverseOneLeaf) {
   db.scan_range(1, 0, fn);
   UNODB_EXPECT_EQ(1, n);
   UNODB_EXPECT_EQ(visited_key, 1);
-  UNODB_EXPECT_TRUE(
-      std::ranges::equal(visited_val, unodb::test::test_values[0]));
+  UNODB_EXPECT_TRUE(std::ranges::equal(visited_val, test_values[0]));
 }
 
 UNODB_TYPED_TEST(ARTScanTest, scanReverseTwoLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(1, unodb::test::test_values[0]);
-  verifier.insert(2, unodb::test::test_values[1]);
+  verifier.insert(1, test_values[0]);
+  verifier.insert(2, test_values[1]);
   uint64_t n = 0;
   std::vector<std::pair<std::uint64_t, unodb::value_view>> visited{};
   auto fn = [&n,
@@ -678,8 +666,8 @@ UNODB_TYPED_TEST(ARTScanTest, scanReverseTwoLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanFromReverseTwoLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(1, unodb::test::test_values[0]);
-  verifier.insert(2, unodb::test::test_values[1]);
+  verifier.insert(1, test_values[0]);
+  verifier.insert(2, test_values[1]);
   uint64_t n = 0;
   std::vector<std::pair<std::uint64_t, unodb::value_view>> visited{};
   auto fn = [&n,
@@ -698,8 +686,8 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromReverseTwoLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanRangeReverseTwoLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(1, unodb::test::test_values[0]);
-  verifier.insert(2, unodb::test::test_values[1]);
+  verifier.insert(1, test_values[0]);
+  verifier.insert(2, test_values[1]);
   uint64_t n = 0;
   std::vector<std::pair<std::uint64_t, unodb::value_view>> visited{};
   auto fn = [&n,
@@ -718,9 +706,9 @@ UNODB_TYPED_TEST(ARTScanTest, scanRangeReverseTwoLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanReverseThreeLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(1, unodb::test::test_values[0]);
-  verifier.insert(2, unodb::test::test_values[1]);
-  verifier.insert(3, unodb::test::test_values[2]);
+  verifier.insert(1, test_values[0]);
+  verifier.insert(2, test_values[1]);
+  verifier.insert(3, test_values[2]);
   uint64_t n = 0;
   uint64_t expected = 3;
   const auto fn = [&n, &expected](
@@ -739,10 +727,10 @@ UNODB_TYPED_TEST(ARTScanTest, scanReverseThreeLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanReverseFourLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
-  verifier.insert(2, unodb::test::test_values[2]);
-  verifier.insert(3, unodb::test::test_values[3]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
+  verifier.insert(2, test_values[2]);
+  verifier.insert(3, test_values[3]);
   uint64_t n = 0;
   uint64_t expected = 3;
   const auto fn = [&n, &expected](
@@ -761,11 +749,11 @@ UNODB_TYPED_TEST(ARTScanTest, scanReverseFourLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanReverseFiveLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(1, unodb::test::test_values[0]);
-  verifier.insert(2, unodb::test::test_values[1]);
-  verifier.insert(3, unodb::test::test_values[2]);
-  verifier.insert(4, unodb::test::test_values[3]);
-  verifier.insert(5, unodb::test::test_values[4]);
+  verifier.insert(1, test_values[0]);
+  verifier.insert(2, test_values[1]);
+  verifier.insert(3, test_values[2]);
+  verifier.insert(4, test_values[3]);
+  verifier.insert(5, test_values[4]);
   uint64_t n = 0;
   uint64_t expected = 5;
   const auto fn = [&n, &expected](
@@ -784,11 +772,11 @@ UNODB_TYPED_TEST(ARTScanTest, scanReverseFiveLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanFromReverseFiveLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(1, unodb::test::test_values[0]);
-  verifier.insert(2, unodb::test::test_values[1]);
-  verifier.insert(3, unodb::test::test_values[2]);
-  verifier.insert(4, unodb::test::test_values[3]);
-  verifier.insert(5, unodb::test::test_values[4]);
+  verifier.insert(1, test_values[0]);
+  verifier.insert(2, test_values[1]);
+  verifier.insert(3, test_values[2]);
+  verifier.insert(4, test_values[3]);
+  verifier.insert(5, test_values[4]);
   uint64_t n = 0;
   uint64_t expected = 5;
   const auto fn = [&n, &expected](
@@ -807,11 +795,11 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromReverseFiveLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanRangeReverseFiveLeaves) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(1, unodb::test::test_values[0]);
-  verifier.insert(2, unodb::test::test_values[1]);
-  verifier.insert(3, unodb::test::test_values[2]);
-  verifier.insert(4, unodb::test::test_values[3]);
-  verifier.insert(5, unodb::test::test_values[4]);
+  verifier.insert(1, test_values[0]);
+  verifier.insert(2, test_values[1]);
+  verifier.insert(3, test_values[2]);
+  verifier.insert(4, test_values[3]);
+  verifier.insert(5, test_values[4]);
   uint64_t n = 0;
   uint64_t expected = 5;
   const auto fn = [&n, &expected](
@@ -830,11 +818,11 @@ UNODB_TYPED_TEST(ARTScanTest, scanRangeReverseFiveLeaves) {
 UNODB_TYPED_TEST(ARTScanTest, scanReverseFiveLeavesHaltEarly) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
-  verifier.insert(2, unodb::test::test_values[2]);
-  verifier.insert(3, unodb::test::test_values[3]);
-  verifier.insert(4, unodb::test::test_values[4]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
+  verifier.insert(2, test_values[2]);
+  verifier.insert(3, test_values[3]);
+  verifier.insert(4, test_values[4]);
   uint64_t n = 0;
   const auto fn =
       [&n](const unodb::visitor<typename TypeParam::iterator>&) noexcept {
@@ -848,11 +836,11 @@ UNODB_TYPED_TEST(ARTScanTest, scanReverseFiveLeavesHaltEarly) {
 UNODB_TYPED_TEST(ARTScanTest, scanFromReverseFiveLeavesHaltEarly) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
-  verifier.insert(2, unodb::test::test_values[2]);
-  verifier.insert(3, unodb::test::test_values[3]);
-  verifier.insert(4, unodb::test::test_values[4]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
+  verifier.insert(2, test_values[2]);
+  verifier.insert(3, test_values[3]);
+  verifier.insert(4, test_values[4]);
   uint64_t n = 0;
   const auto fn =
       [&n](const unodb::visitor<typename TypeParam::iterator>&) noexcept {
@@ -866,11 +854,11 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromReverseFiveLeavesHaltEarly) {
 UNODB_TYPED_TEST(ARTScanTest, scanRangeReverseFiveLeavesHaltEarly) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();  // reference to test db instance.
-  verifier.insert(0, unodb::test::test_values[0]);
-  verifier.insert(1, unodb::test::test_values[1]);
-  verifier.insert(2, unodb::test::test_values[2]);
-  verifier.insert(3, unodb::test::test_values[3]);
-  verifier.insert(4, unodb::test::test_values[4]);
+  verifier.insert(0, test_values[0]);
+  verifier.insert(1, test_values[1]);
+  verifier.insert(2, test_values[2]);
+  verifier.insert(3, test_values[3]);
+  verifier.insert(4, test_values[4]);
   uint64_t n = 0;
   const auto fn =
       [&n](const unodb::visitor<typename TypeParam::iterator>&) noexcept {
@@ -1088,7 +1076,7 @@ UNODB_TYPED_TEST(ARTScanTest, scanFromBacktrackAcrossSiblingSubtrees) {
   unodb::test::tree_verifier<TypeParam> verifier;
   TypeParam& db = verifier.get_db();
   for (const std::uint64_t k : {100U, 200U, 300U, 400U, 500U})
-    verifier.insert(k, unodb::test::test_values[0]);
+    verifier.insert(k, test_values[0]);
   // FWD: scan_from(250) should find 300, 400, 500.
   {
     std::vector<std::uint64_t> results;

--- a/test/test_art_upsert.cpp
+++ b/test/test_art_upsert.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "art_common.hpp"
+#include "art_test_data.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
 #include "olc_art.hpp"  // NOLINT(misc-include-cleaner)
@@ -448,7 +449,7 @@ UNODB_TYPED_TEST(UpsertTest, TypeCoverageKeyViewValueView) {
     unodb::test::tree_verifier<TypeParam> verifier;
     auto& db = verifier.get_db();
     const auto k = verifier.coerce_key(3);
-    const auto v = unodb::test::test_values[2];
+    const auto v = unodb::test_data::test_values[2];
     with_qsbr<TypeParam>([&] { UNODB_ASSERT_TRUE(db.insert(k, v)); });
     // keep
     with_qsbr<TypeParam>([&] { UNODB_ASSERT_FALSE(db.upsert(k, v, keep_fn)); });
@@ -471,7 +472,7 @@ UNODB_TYPED_TEST(UpsertTest, TypeCoverageU64ValueView) {
     unodb::test::tree_verifier<TypeParam> verifier;
     auto& db = verifier.get_db();
     const auto k = verifier.coerce_key(10);
-    const auto v = unodb::test::test_values[3];
+    const auto v = unodb::test_data::test_values[3];
     with_qsbr<TypeParam>([&] { UNODB_ASSERT_TRUE(db.insert(k, v)); });
     // keep
     with_qsbr<TypeParam>([&] { UNODB_ASSERT_FALSE(db.upsert(k, v, keep_fn)); });
@@ -826,7 +827,7 @@ UNODB_TYPED_TEST(UpsertConcurrencyTest, OlcRestart) {
     unodb::test::detail::assert_value_eq<TypeParam>(result, v0);
   } else {
     const auto expected = static_cast<typename TypeParam::value_type>(
-        unodb::test::test_values_u64[0] + 1);
+        unodb::test_data::test_values_u64[0] + 1);
     unodb::test::detail::assert_value_eq<TypeParam>(result, expected);
   }
 }


### PR DESCRIPTION
(LLM agent)

Several test and benchmark targets duplicated the same ART test data and
key-encoding recipes, some byte-identical across four translation units. This
moves them into a new repo-root `art_test_data.hpp` of pure test data and
`key_encoder` helpers, free of Google Test and database template dependencies,
so any test or benchmark target can include it without linking extra libraries.
The data lives in a new `unodb::test_data` namespace, documented in
`modules.dox`.

Net −258 lines across 14 files.

Consolidated: `test_value_1..5` and friends out of `db_test_utils.hpp`;
`make_key`/`make_short_key`/`make_long_key`; the chain-shape builders (up to 16
copies), renamed by their true encoded sizes — the 3-argument `make18` actually
built an 11-byte key and is now `make_key_11`; the chain filler words; the
too-long key/value rejection views; the encoded-text word list; the uint64
decode helper (four copies plus five open-coded expansions); and the
copy-encoded-key-to-caller-buffer lambda, now the shared `copy_key`.

The `make_*` builders return a view into the caller's `key_encoder` buffer,
which any later non-const call on that encoder invalidates. That contract was
previously implicit at each open-coded site and is now stated once as a
file-level `\warning`, naming the three sanctioned patterns already used in the
tree. Every parameter the return value aliases carries
`UNODB_DETAIL_LIFETIMEBOUND`, so returning a view out of a function whose
backing storage is a local is diagnosed; `copy_key`'s `kv` and
`make_chain_key`'s `enc` are deliberately left unannotated, because the copy
severs the dependency on both.

`ConcurrentRemoveDuringChainInsert` followed that rule only by coincidence — its
T2 re-encoded the same tag into the encoder backing a still-live `k_seed2`, so
the closing assertion read bytes T2 had rewritten. T2 now removes `k_seed2`
directly.

The rejection views are deliberately functions rather than `constexpr`
variables: their length exceeds the single byte they point at, and under
`_GLIBCXX_DEBUG` libstdc++'s span constructor forms `ptr + count`.
Constant-initializing that offset past a one-byte object is not a core constant
expression, so Clang rejects it outright while GCC and libc++ accept it — which
is why it is invisible in local macOS and GCC builds.

See the commit message for the full rationale, including why the encoded-text
word list keeps its unsorted order (it is load-bearing for
`basic_inode_16::add_to_nonfull`'s `copy_backward` branch) and why `make_key_17`
keeps a distinct name per shape rather than overloading on argument count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized ART test data, key fixtures, and decoding across benchmarks and test suites.
  * Preserved existing scenarios, assertions, and coverage while simplifying test setup.
  * Added validation for oversized inputs, key construction, encoded keys, and decoding behavior.
  * Improved consistency for concurrency, scanning, iteration, bulk-loading, and out-of-memory test coverage.

* **Documentation**
  * Documented the shared ART test utilities and clarified that they are intended for internal testing only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->