### PR TITLE
Make basic_node_ptr's nullptr interop constexpr

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -67,6 +67,17 @@ using node_ptr = basic_node_ptr<node_header>;
 
 static_assert(sizeof(node_ptr) == sizeof(void*));
 
+static_assert(node_ptr{nullptr} == nullptr,
+              "the nullptr constructor and comparison must be "
+              "constant-evaluable");
+static_assert((node_ptr{nullptr} = nullptr) == nullptr,
+              "the nullptr assignment must be constant-evaluable");
+static_assert(node_ptr{nullptr}.raw_val() == 0,
+              "the null must be the all-zero tagged value that "
+              "basic_inode_48's free-slot scan compares against");
+static_assert(node_ptr{} == nullptr,
+              "value-initialization must produce the null node_ptr");
+
 struct impl_helpers;
 
 /// Type definitions bundle for all internal node types.

--- a/art_internal.hpp
+++ b/art_internal.hpp
@@ -407,6 +407,14 @@ class basic_db_inode_deleter {
 /// You have to know statically the target type, then call
 /// `node_ptr_var.ptr<target_type*>()` to get `target_type*`.
 ///
+/// A null `basic_node_ptr` is the all-zero tagged value.
+///
+/// \note The three `std::nullptr_t` members below spell that value as a literal
+/// `0` rather than as `reinterpret_cast<std::uintptr_t>(nullptr)`: a
+/// `reinterpret_cast` is not a core constant expression, so the cast would cost
+/// them their `constexpr`. The `static_assert`s at the node_ptr / olc_node_ptr
+/// alias definitions force compilers to constant-evaluate them.
+///
 /// \tparam Header Node header type
 template <class Header>
 class [[nodiscard]] basic_node_ptr {
@@ -421,13 +429,8 @@ class [[nodiscard]] basic_node_ptr {
   // cppcheck-suppress uninitMemberVar
   constexpr basic_node_ptr() noexcept = default;
 
-  UNODB_DETAIL_DISABLE_MSVC_WARNING(26490)
-
   /// Construct null pointer.
-  explicit basic_node_ptr(std::nullptr_t) noexcept
-      : tagged_ptr{reinterpret_cast<std::uintptr_t>(nullptr)} {}
-
-  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
+  constexpr explicit basic_node_ptr(std::nullptr_t) noexcept : tagged_ptr{0} {}
 
   /// Construct from raw pointer and node type.
   ///
@@ -437,17 +440,13 @@ class [[nodiscard]] basic_node_ptr {
                  unodb::node_type type) noexcept
       : tagged_ptr{tag_ptr(ptr, type)} {}
 
-  UNODB_DETAIL_DISABLE_MSVC_WARNING(26490)
-
   /// Assign null pointer.
   ///
   /// \return Reference to this
-  basic_node_ptr<Header>& operator=(std::nullptr_t) noexcept {
-    tagged_ptr = reinterpret_cast<std::uintptr_t>(nullptr);
+  constexpr basic_node_ptr<Header>& operator=(std::nullptr_t) noexcept {
+    tagged_ptr = 0;
     return *this;
   }
-
-  UNODB_DETAIL_RESTORE_MSVC_WARNINGS()
 
   /// Get node type from tag bits.
   ///
@@ -485,18 +484,19 @@ class [[nodiscard]] basic_node_ptr {
     return tagged_ptr == other.tagged_ptr;
   }
 
-  UNODB_DETAIL_DISABLE_MSVC_WARNING(26490)
-
   /// Compare with nullptr.
   ///
   /// \return True if this is a null pointer
-  [[nodiscard, gnu::pure]] bool operator==(std::nullptr_t) const noexcept {
-    return tagged_ptr == reinterpret_cast<std::uintptr_t>(nullptr);
+  [[nodiscard, gnu::pure]] constexpr bool operator==(
+      std::nullptr_t) const noexcept {
+    return tagged_ptr == 0;
   }
 
  private:
   /// Tagged pointer value with node type in low bits.
   std::uintptr_t tagged_ptr;
+
+  UNODB_DETAIL_DISABLE_MSVC_WARNING(26490)
 
   /// Create tagged pointer from raw pointer \a ptr_ and node type \a tag.
   ///

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -117,6 +117,17 @@ using olc_node_ptr = basic_node_ptr<olc_node_header>;
 
 static_assert(sizeof(olc_node_ptr) == sizeof(void*));
 
+static_assert(olc_node_ptr{nullptr} == nullptr,
+              "the nullptr constructor and comparison must be "
+              "constant-evaluable");
+static_assert((olc_node_ptr{nullptr} = nullptr) == nullptr,
+              "the nullptr assignment must be constant-evaluable");
+static_assert(olc_node_ptr{nullptr}.raw_val() == 0,
+              "the null must be the all-zero tagged value that "
+              "basic_inode_48's free-slot scan compares against");
+static_assert(olc_node_ptr{} == nullptr,
+              "value-initialization must produce the null olc_node_ptr");
+
 template <typename, typename, class>
 class db_inode_qsbr_deleter;  // IWYU pragma: keep
 


### PR DESCRIPTION
(LLM agent)

The nullptr constructor, nullptr assignment, and nullptr comparison of `basic_node_ptr` spelled the null tagged value as `reinterpret_cast<std::uintptr_t>(nullptr)`, which is not a core constant expression, so none of the three could be `constexpr` — against the CONTRIBUTING.md rule that `constexpr` be applied everywhere it is legal. Spell the null as literal zero instead and make all three `constexpr`.

`static_assert`s at the `node_ptr` / `olc_node_ptr` alias definitions pin the constexpr-ness, the all-zero object representation (which `basic_inode_48`'s SIMD free-slot scan depends on), and the value-initialized null. The MSVC C26490 suppressions left in `basic_node_ptr` are the two wrapping a genuine pointer/integer reinterpretation, in `ptr()` and `tag_ptr`.

Prerequisite for the follow-up OLC torn-read fix in `inode_48`/`inode_256` `begin()`/`last()`, which expresses the torn-read sentinel as a `static constexpr iter_result` built from `node_ptr{nullptr}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179XxEgdc4uJt9dejSygWx3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null-pointer handling for node pointers.
  * Null construction, assignment, comparison, and value initialization now support compile-time evaluation.
  * Ensured null pointers consistently use an all-zero representation for reliable behavior.

* **Tests**
  * Added compile-time checks validating null-pointer behavior across supported pointer types.
  * Verified that null values retain the expected representation in raw form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->