### PR TITLE
Make iter_result's flag the packed-value flag its doc describes

### DIFF
--- a/art.hpp
+++ b/art.hpp
@@ -655,7 +655,7 @@ class db final {
           static_cast<std::byte>(0xFFU),     // ignored for leaf
           static_cast<std::uint8_t>(0xFFU),  // ignored for leaf
           detail::key_prefix_snapshot(0),    // ignored for leaf
-          true                               // packed_leaf
+          art_policy::can_eliminate_leaf     // is_packed_value
       });
       // No change in the key_buffer.
     }
@@ -684,8 +684,7 @@ class db final {
 
       const auto& e = top();
       const auto n = static_cast<std::size_t>(
-          (!(art_policy::can_eliminate_leaf && e.packed_leaf) &&
-           e.node.type() != node_type::LEAF)
+          (!e.is_packed_value && e.node.type() != node_type::LEAF)
               ? e.prefix.length() + 1
               : 0);
       keybuf_.pop(n);
@@ -2174,10 +2173,9 @@ typename db<Key, Value>::iterator& db<Key, Value>::iterator::next() {
   while (!empty()) {
     const auto& e = top();
     const auto node{e.node};
-    UNODB_DETAIL_ASSERT(node != nullptr || e.packed_leaf);
+    UNODB_DETAIL_ASSERT(node != nullptr || e.is_packed_value);
     const auto node_type = node.type();
-    if (node_type == node_type::LEAF ||
-        (art_policy::can_eliminate_leaf && e.packed_leaf)) {
+    if (node_type == node_type::LEAF || e.is_packed_value) {
       pop();     // pop off the leaf
       continue;  // falls through loop if just a root leaf since stack now
                  // empty.
@@ -2210,10 +2208,9 @@ typename db<Key, Value>::iterator& db<Key, Value>::iterator::prior() {
   while (!empty()) {
     const auto& e = top();
     const auto node{e.node};
-    UNODB_DETAIL_ASSERT(node != nullptr || e.packed_leaf);
+    UNODB_DETAIL_ASSERT(node != nullptr || e.is_packed_value);
     const auto node_type = node.type();
-    if (node_type == node_type::LEAF ||
-        (art_policy::can_eliminate_leaf && e.packed_leaf)) {
+    if (node_type == node_type::LEAF || e.is_packed_value) {
       pop();     // pop off the leaf
       continue;  // falls through loop if just a root leaf since stack now
                  // empty.

--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -1562,11 +1562,18 @@ struct iter_result {
   /// Snapshot of key prefix for node.
   key_prefix_snapshot prefix;
 
-  /// True when this entry represents a packed value (value-in-slot) rather
-  /// than an inode or leaf pointer.  Used by the iterator to distinguish
-  /// value-in-slot entries from regular children whose child_index happens
-  /// to equal 0xFF.
-  bool packed_leaf{false};
+  /// True when #node holds a packed value (value-in-slot) rather than an
+  /// inode or leaf pointer.  Set by unodb::db::iterator::push_leaf() and
+  /// unodb::olc_db::iterator::try_push_leaf(), the only writers, and only
+  /// under basic_art_policy::can_eliminate_leaf, where the tree has no leaf
+  /// nodes at all; elsewhere a leaf position carries a genuine leaf pointer
+  /// and this stays false.
+  ///
+  /// A leaf position is therefore `is_packed_value || node.type() ==
+  /// node_type::LEAF`, never `child_index == 0xFF`: `child_index` is `0xFF`
+  /// there only as a placeholder, and `0xFF` is a valid child index in
+  /// basic_inode_48 and basic_inode_256.
+  bool is_packed_value{false};
 };
 
 /// Optional wrapper for iter_result.
@@ -2174,7 +2181,7 @@ class basic_inode_impl : public ArtPolicy::header_type {
   /// tripwire on each side: structural corruption for db, a missed version
   /// bump for olc_db. Both assert in the dispatcher rather than at the callers
   /// so that every producer is covered, and so that the null is caught before
-  /// push_leaf() / try_push_leaf() stamps packed_leaf on it: under
+  /// push_leaf() / try_push_leaf() stamps is_packed_value on it: under
   /// ArtPolicy::can_eliminate_leaf it would then be indistinguishable from a
   /// legitimate packed zero and unpack_value() would return 0, and otherwise
   /// the entry would be dereferenced as a leaf.

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -569,7 +569,7 @@ class olc_db final {
                     static_cast<std::byte>(0xFFU),     // ignored for leaf
                     static_cast<std::uint8_t>(0xFFU),  // ignored for leaf
                     detail::key_prefix_snapshot(0),    // ignored for leaf
-                    true},                             // packed_leaf
+                    art_policy::can_eliminate_leaf},   // is_packed_value
                    rcs.get()});
       return true;
     }
@@ -605,8 +605,7 @@ class olc_db final {
       // each of them.
       const auto& e = top();
       const auto n = static_cast<std::size_t>(
-          (!(art_policy::can_eliminate_leaf && e.packed_leaf) &&
-           e.node.type() != node_type::LEAF)
+          (!e.is_packed_value && e.node.type() != node_type::LEAF)
               ? e.prefix.length() + 1
               : 0);
       keybuf_.pop(n);
@@ -3907,14 +3906,12 @@ bool olc_db<Key, Value>::iterator::try_last() {
 template <typename Key, typename Value>
 typename olc_db<Key, Value>::iterator& olc_db<Key, Value>::iterator::next() {
   const auto node = current_node();
-  if (node != nullptr ||
-      (art_policy::can_eliminate_leaf && !empty() && top().packed_leaf)) {
+  if (node != nullptr || (!empty() && top().is_packed_value)) {
     const art_key_type akey{[&]() noexcept -> art_key_type {
       if constexpr (art_policy::full_key_in_inode_path) {
         return art_key_type{keybuf_.get_key_view()};
       } else {
-        UNODB_DETAIL_ASSERT(
-            !(art_policy::can_eliminate_leaf && stack_.top().packed_leaf));
+        UNODB_DETAIL_ASSERT(!stack_.top().is_packed_value);
         UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);
         return node.template ptr<leaf_type*>()->get_key();
       }
@@ -3941,15 +3938,11 @@ bool olc_db<Key, Value>::iterator::try_next() {
   while (!empty()) {
     const auto& e = top();
     const auto node{e.node};  // the node on the top of the stack.
-    UNODB_DETAIL_ASSERT(node != nullptr ||
-                        (art_policy::can_eliminate_leaf && e.packed_leaf));
-    // Packed values (value-in-slot) are pushed with packed_leaf=true.
-    // They have no valid lock — just pop and continue.
-    if constexpr (art_policy::can_eliminate_leaf) {
-      if (e.packed_leaf) {
-        pop();
-        continue;
-      }
+    UNODB_DETAIL_ASSERT(node != nullptr || e.is_packed_value);
+    // Packed values have no valid lock — just pop and continue.
+    if (e.is_packed_value) {
+      pop();
+      continue;
     }
     auto node_critical_section(
         node_ptr_lock(node).rehydrate_read_lock(e.version));
@@ -4000,14 +3993,12 @@ bool olc_db<Key, Value>::iterator::try_next() {
 template <typename Key, typename Value>
 typename olc_db<Key, Value>::iterator& olc_db<Key, Value>::iterator::prior() {
   const auto node = current_node();
-  if (node != nullptr ||
-      (art_policy::can_eliminate_leaf && !empty() && top().packed_leaf)) {
+  if (node != nullptr || (!empty() && top().is_packed_value)) {
     const art_key_type akey{[&]() noexcept -> art_key_type {
       if constexpr (art_policy::full_key_in_inode_path) {
         return art_key_type{keybuf_.get_key_view()};
       } else {
-        UNODB_DETAIL_ASSERT(
-            !(art_policy::can_eliminate_leaf && stack_.top().packed_leaf));
+        UNODB_DETAIL_ASSERT(!stack_.top().is_packed_value);
         UNODB_DETAIL_ASSERT(node.type() == node_type::LEAF);
         return node.template ptr<leaf_type*>()->get_key();
       }
@@ -4035,13 +4026,11 @@ bool olc_db<Key, Value>::iterator::try_prior() {
   while (!empty()) {
     const auto& e = top();
     const auto node{e.node};  // the node on the top of the stack.
-    UNODB_DETAIL_ASSERT(node != nullptr ||
-                        (art_policy::can_eliminate_leaf && e.packed_leaf));
-    if constexpr (art_policy::can_eliminate_leaf) {
-      if (e.packed_leaf) {
-        pop();
-        continue;
-      }
+    UNODB_DETAIL_ASSERT(node != nullptr || e.is_packed_value);
+    // Packed values have no valid lock — just pop and continue.
+    if (e.is_packed_value) {
+      pop();
+      continue;
     }
     auto node_critical_section(
         node_ptr_lock(node).rehydrate_read_lock(e.version));
@@ -4607,7 +4596,7 @@ auto olc_db<Key, Value>::iterator::get_val() const noexcept
   const auto& e = stack_.top();
   const auto& node = e.node;
   if constexpr (art_policy::can_eliminate_leaf) {
-    if (e.packed_leaf) {
+    if (e.is_packed_value) {
       return art_policy::unpack_value(node);
     }
     UNODB_DETAIL_CANNOT_HAPPEN();  // LCOV_EXCL_LINE

--- a/test/test_art_iter.cpp
+++ b/test/test_art_iter.cpp
@@ -10,13 +10,18 @@
 #include <algorithm>
 #include <cstdint>
 #include <iostream>
+// test_only_stack() returns std::vector, but only through `auto`, which
+// include-cleaner does not attribute to this header.
+#include <vector>  // IWYU pragma: keep
 
 #include <gtest/gtest.h>
 
+#include "art.hpp"
 #include "art_internal.hpp"
 #include "art_test_data.hpp"
 #include "db_test_utils.hpp"
 #include "gtest_utils.hpp"
+#include "node_type.hpp"
 
 namespace {
 
@@ -632,6 +637,38 @@ UNODB_TYPED_TEST(ARTIteratorTest, seekThreeLeavesUnderTheRoot) {
       }
     }
   }
+}
+
+// is_packed_value discriminates a packed value word from a pointer; it is not
+// a leaf-position test. Without can_eliminate_leaf, which the static_assert
+// below pins for this suite, a leaf position carries a genuine LEAF pointer
+// and the flag stays false, so both are asserted at every position. The
+// flag's false side is asserted nowhere else: the only other stack-structure
+// test runs exclusively over value-in-slot types, where the flag is always
+// true.
+UNODB_TYPED_TEST(ARTIteratorTest, leafPositionNotPackedValueWithoutVIS) {
+  // The db and mutex_db legs stamp the flag from art_policy, the olc_db legs
+  // from olc_art_policy, but one policy pins the suite: both alias the same
+  // basic_art_policy, whose can_eliminate_leaf reads only Key and Value.
+  static_assert(!unodb::detail::art_policy<
+                    typename TypeParam::key_type,
+                    typename TypeParam::value_type>::can_eliminate_leaf,
+                "this test's expectations hold only without value-in-slot");
+  unodb::test::tree_verifier<TypeParam> verifier;
+  TypeParam& db = verifier.get_db();  // reference to test db instance.
+  verifier.insert(0xaa00, test_values[0]);
+  verifier.insert(0xaa01, test_values[1]);
+  verifier.insert(0xab00, test_values[2]);
+  auto b = db.test_only_iterator();
+  int positions = 0;
+  for (b.first(); b.valid(); b.next()) {
+    const auto stk = b.test_only_stack();
+    UNODB_ASSERT_FALSE(stk.empty());
+    UNODB_EXPECT_FALSE(stk.back().is_packed_value);
+    UNODB_EXPECT_EQ(stk.back().node.type(), unodb::node_type::LEAF);
+    ++positions;
+  }
+  UNODB_EXPECT_EQ(positions, 3);  // guard against a vacuously empty scan
 }
 
 }  // namespace

--- a/test/test_art_key_view_full_chain.cpp
+++ b/test/test_art_key_view_full_chain.cpp
@@ -5,7 +5,7 @@
 /// These exercise fundamentally different code paths from test_art_key_view.cpp
 /// (which uses db<key_view, value_view>): insert uses build_chain + pack_value
 /// instead of make_db_leaf_ptr, get uses is_value_in_slot + unpack_value,
-/// remove checks value bitmasks, and iterators use the packed_leaf flag.
+/// remove checks value bitmasks, and iterators use the is_packed_value flag.
 /// ~60 test names overlap to verify behavioral equivalence; 9 are unique
 /// (stack structure, collapse guards, empty key rejection).
 


### PR DESCRIPTION
`iter_result`'s doc already said the flag is "True when this entry represents a
packed value (value-in-slot) rather than an inode or leaf pointer". The code did
not: both `push_leaf()` bodies stamped `true` unconditionally, so in the two of
three instantiated configurations without `can_eliminate_leaf` the flag was true
over a genuine leaf pointer. The name `packed_leaf` sided with the code.

Stamp `art_policy::can_eliminate_leaf` rather than `true`, and rename the field
`is_packed_value`. The name is then literally true, and the ten
`can_eliminate_leaf && ...packed_leaf` conjunctions collapse to a bare read; two
more spell the same conjunction as a nested `if constexpr` and collapse with
them.

Control flow is preserved at all twelve sites. Where `can_eliminate_leaf` is
true nothing changes at all, since the stamp was already true there. Where it is
false the flag term is false on both sides.

One site does change, and that is the point. `next()` and `prior()` assert
`node != nullptr || e.packed_leaf`, which was vacuously true at every leaf
position and so tested nothing there. The same text is now a real tripwire: it
tolerates the packed entry, whose word may legitimately be a packed zero, and
requires a non-null pointer everywhere else.

The flag's false side was asserted nowhere — the only stack-structure test runs
over value-in-slot types, where the flag is always true. `ARTIteratorTest`
therefore gains `leafPositionNotPackedValueWithoutVIS`, which scans a three-leaf
tree over all six non-VIS configurations and requires the flag false at every
position, failing on both `db` legs if either stamp regresses to `true`.

One bit was answering two questions, "is this a leaf position?" and "is this a
packed word rather than a pointer?", which coincide only under
`can_eliminate_leaf`. It now answers the second.

Full rationale, including the naming choice and the doc split, is in the commit
message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLViPGjhCEULw3mWfNRMkh


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iterator handling for packed values and leaf nodes during forward and reverse traversal.
  * Ensured leaf entries are identified consistently, including when packed-value optimization is unavailable.
  * Prevented incorrect iterator positions in trees containing multiple leaf nodes.

* **Tests**
  * Added coverage validating leaf traversal and packed-value markers.
  * Updated iterator documentation references to reflect the current terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->