### PR TITLE
Make olc_db::iterator's push helpers void and drop 21 dead guards

### DIFF
--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -1566,10 +1566,10 @@ struct iter_result {
 
   /// True when #node holds a packed value (value-in-slot) rather than an
   /// inode or leaf pointer.  Set by unodb::db::iterator::push_leaf() and
-  /// unodb::olc_db::iterator::try_push_leaf(), the only writers, and only
-  /// under basic_art_policy::can_eliminate_leaf, where the tree has no leaf
-  /// nodes at all; elsewhere a leaf position carries a genuine leaf pointer
-  /// and this stays false.
+  /// unodb::olc_db::iterator::push_leaf(), the only writers, and only under
+  /// basic_art_policy::can_eliminate_leaf, where the tree has no leaf nodes
+  /// at all; elsewhere a leaf position carries a genuine leaf pointer and
+  /// this stays false.
   ///
   /// A leaf position is therefore `is_packed_value || node.type() ==
   /// node_type::LEAF`, never `child_index == 0xFF`: `child_index` is `0xFF`
@@ -2179,13 +2179,12 @@ class basic_inode_impl : public ArtPolicy::header_type {
   /// `read_critical_section::check()` fails before the result is used. The
   /// single-threaded db traversals take no critical section at all and cannot
   /// observe this value. Both db::iterator::push() and
-  /// olc_db::iterator::try_push() assert the node is non-null, keeping a
-  /// tripwire on each side: structural corruption for db, a missed version
-  /// bump for olc_db. Asserting in the dispatcher rather than at each caller
-  /// covers every producer and names the fault. The 4- and 5-argument
-  /// push()/try_push() they forward to would reject a null as well, since a
-  /// null node_ptr reports node_type::LEAF, but only as a generic type
-  /// violation.
+  /// olc_db::iterator::push() assert the node is non-null, keeping a tripwire
+  /// on each side: structural corruption for db, a missed version bump for
+  /// olc_db. Asserting in the dispatcher rather than at each caller covers
+  /// every producer and names the fault. The 4- and 5-argument push() they
+  /// forward to would reject a null as well, since a null node_ptr reports
+  /// node_type::LEAF, but only as a generic type violation.
   ///
   /// \sa get_child(node_type, std::uint8_t), which returns nullptr on the same
   /// torn read

--- a/olc_art.hpp
+++ b/olc_art.hpp
@@ -545,9 +545,9 @@ class olc_db final {
     [[nodiscard]] bool empty() const noexcept { return stack_.empty(); }
 
     /// Push an entry onto the stack.
-    bool try_push(detail::olc_node_ptr node, std::byte key_byte,
-                  std::uint8_t child_index, detail::key_prefix_snapshot prefix,
-                  const optimistic_lock::read_critical_section& rcs) {
+    void push(detail::olc_node_ptr node, std::byte key_byte,
+              std::uint8_t child_index, detail::key_prefix_snapshot prefix,
+              const optimistic_lock::read_critical_section& rcs) {
       // For variable length keys we need to know the number of bytes
       // associated with the node's key_prefix.  In addition there is
       // one byte for the descent to the child node along the
@@ -558,12 +558,11 @@ class olc_db final {
       stack_.push({{node, key_byte, child_index, prefix}, rcs.get()});
       keybuf_.push(prefix.get_key_view());
       keybuf_.push(key_byte);
-      return true;
     }
 
     /// Push a leaf onto the stack.
-    bool try_push_leaf(detail::olc_node_ptr aleaf,
-                       const optimistic_lock::read_critical_section& rcs) {
+    void push_leaf(detail::olc_node_ptr aleaf,
+                   const optimistic_lock::read_critical_section& rcs) {
       // The [key], [child_index] and [prefix] are ignored for a leaf.
       stack_.push({{aleaf,
                     static_cast<std::byte>(0xFFU),     // ignored for leaf
@@ -571,7 +570,6 @@ class olc_db final {
                     detail::key_prefix_snapshot(0),    // ignored for leaf
                     art_policy::can_eliminate_leaf},   // is_packed_value
                    rcs.get()});
-      return true;
     }
 
     /// Push an entry \a e onto the stack.
@@ -583,10 +581,10 @@ class olc_db final {
     ///
     /// \sa detail::basic_inode_impl::torn_read_result for why the assert lives
     /// here rather than at the callers
-    bool try_push(const typename inode_base::iter_result& e,
-                  const optimistic_lock::read_critical_section& rcs) {
+    void push(const typename inode_base::iter_result& e,
+              const optimistic_lock::read_critical_section& rcs) {
       UNODB_DETAIL_ASSERT(e.node != nullptr);
-      return try_push(e.node, e.key_byte, e.child_index, e.prefix, rcs);
+      push(e.node, e.key_byte, e.child_index, e.prefix, rcs);
     }
 
     /// Pop an entry from the stack and the corresponding bytes from
@@ -3974,15 +3972,13 @@ bool olc_db<Key, Value>::iterator::try_next() {
     // Fix up stack for new parent node state and left-most descent.
     const auto& e2 = nxt.value();
     pop();
-    if (UNODB_DETAIL_UNLIKELY(!try_push(e2, node_critical_section)))
-      return false;                                            // LCOV_EXCL_LINE
-    auto child = inode->get_child(node_type, e2.child_index);  // descend
+    push(e2, node_critical_section);
+    auto child = inode->get_child(node_type, e2.child_index);   // descend
     if (UNODB_DETAIL_UNLIKELY(!node_critical_section.check()))  // before using
       return false;  // LCOV_EXCL_LINE
     if constexpr (art_policy::can_eliminate_leaf) {
       if (inode->is_value_in_slot(node_type, e2.child_index)) {
-        if (UNODB_DETAIL_UNLIKELY(!try_push_leaf(child, node_critical_section)))
-          return false;  // LCOV_EXCL_LINE
+        push_leaf(child, node_critical_section);
         return UNODB_DETAIL_LIKELY(node_critical_section.try_read_unlock());
       }
     }
@@ -4058,15 +4054,13 @@ bool olc_db<Key, Value>::iterator::try_prior() {
     UNODB_DETAIL_ASSERT(nxt);  // value exists for std::optional.
     const auto& e2 = nxt.value();
     pop();
-    if (UNODB_DETAIL_UNLIKELY(!try_push(e2, node_critical_section)))
-      return false;                                            // LCOV_EXCL_LINE
-    auto child = inode->get_child(node_type, e2.child_index);  // get child
+    push(e2, node_critical_section);
+    auto child = inode->get_child(node_type, e2.child_index);   // get child
     if (UNODB_DETAIL_UNLIKELY(!node_critical_section.check()))  // before using
       return false;  // LCOV_EXCL_LINE
     if constexpr (art_policy::can_eliminate_leaf) {
       if (inode->is_value_in_slot(node_type, e2.child_index)) {
-        if (UNODB_DETAIL_UNLIKELY(!try_push_leaf(child, node_critical_section)))
-          return false;  // LCOV_EXCL_LINE
+        push_leaf(child, node_critical_section);
         return UNODB_DETAIL_LIKELY(node_critical_section.try_read_unlock());
       }
     }
@@ -4161,8 +4155,7 @@ bool olc_db<Key, Value>::iterator::try_seek(art_key_type search_key,
               !parent_critical_section.try_read_unlock()))  // unlock parent
         return false;                                       // LCOV_EXCL_LINE
       const auto* const leaf{node.template ptr<leaf_type*>()};
-      if (UNODB_DETAIL_UNLIKELY(!try_push_leaf(node, node_critical_section)))
-        return false;  // LCOV_EXCL_LINE
+      push_leaf(node, node_critical_section);
       int cmp_{0};
       if constexpr (art_policy::full_key_in_inode_path) {
         cmp_ = unodb::detail::compare(keybuf_.get_key_view(), k.get_key_view());
@@ -4297,14 +4290,10 @@ bool olc_db<Key, Value>::iterator::try_seek(art_key_type search_key,
                       !c_critical_section.check()))  // before using [nchild]
                 return false;                        // LCOV_EXCL_LINE
               pop();
-              if (UNODB_DETAIL_UNLIKELY(
-                      !try_push(e2, c_critical_section)))  // push sibling
-                return false;                              // LCOV_EXCL_LINE
+              push(e2, c_critical_section);  // push sibling
               if constexpr (art_policy::can_eliminate_leaf) {
                 if (icnode->is_value_in_slot(cnode.type(), e2.child_index)) {
-                  if (UNODB_DETAIL_UNLIKELY(
-                          !try_push_leaf(nchild, c_critical_section)))
-                    return false;  // LCOV_EXCL_LINE
+                  push_leaf(nchild, c_critical_section);
                   return UNODB_DETAIL_LIKELY(
                       c_critical_section.try_read_unlock());
                 }
@@ -4328,14 +4317,11 @@ bool olc_db<Key, Value>::iterator::try_seek(art_key_type search_key,
                 !parent_critical_section.try_read_unlock()))  // unlock parent
           return false;                                       // LCOV_EXCL_LINE
         // push the path we took
-        if (UNODB_DETAIL_UNLIKELY(!try_push(node, tmp.key_byte, child_index,
-                                            tmp.prefix, node_critical_section)))
-          return false;  // LCOV_EXCL_LINE
+        push(node, tmp.key_byte, child_index, tmp.prefix,
+             node_critical_section);
         if constexpr (art_policy::can_eliminate_leaf) {
           if (inode->is_value_in_slot(node_type, child_index)) {
-            if (UNODB_DETAIL_UNLIKELY(
-                    !try_push_leaf(child, node_critical_section)))
-              return false;  // LCOV_EXCL_LINE
+            push_leaf(child, node_critical_section);
             return UNODB_DETAIL_LIKELY(node_critical_section.try_read_unlock());
           }
         }
@@ -4376,14 +4362,10 @@ bool olc_db<Key, Value>::iterator::try_seek(art_key_type search_key,
                     !c_critical_section.check()))  // before using [nchild]
               return false;                        // LCOV_EXCL_LINE
             pop();
-            if (UNODB_DETAIL_UNLIKELY(
-                    !try_push(e2, c_critical_section)))  // push sibling
-              return false;                              // LCOV_EXCL_LINE
+            push(e2, c_critical_section);  // push sibling
             if constexpr (art_policy::can_eliminate_leaf) {
               if (icnode->is_value_in_slot(cnode.type(), e2.child_index)) {
-                if (UNODB_DETAIL_UNLIKELY(
-                        !try_push_leaf(nchild, c_critical_section)))
-                  return false;  // LCOV_EXCL_LINE
+                push_leaf(nchild, c_critical_section);
                 return UNODB_DETAIL_LIKELY(
                     c_critical_section.try_read_unlock());
               }
@@ -4407,14 +4389,10 @@ bool olc_db<Key, Value>::iterator::try_seek(art_key_type search_key,
               !parent_critical_section.try_read_unlock()))  // unlock parent
         return false;                                       // LCOV_EXCL_LINE
       // push the path we took
-      if (UNODB_DETAIL_UNLIKELY(!try_push(node, tmp.key_byte, child_index,
-                                          tmp.prefix, node_critical_section)))
-        return false;  // LCOV_EXCL_LINE
+      push(node, tmp.key_byte, child_index, tmp.prefix, node_critical_section);
       if constexpr (art_policy::can_eliminate_leaf) {
         if (inode->is_value_in_slot(node_type, child_index)) {
-          if (UNODB_DETAIL_UNLIKELY(
-                  !try_push_leaf(child, node_critical_section)))
-            return false;  // LCOV_EXCL_LINE
+          push_leaf(child, node_critical_section);
           return UNODB_DETAIL_LIKELY(node_critical_section.try_read_unlock());
         }
       }
@@ -4423,9 +4401,8 @@ bool olc_db<Key, Value>::iterator::try_seek(art_key_type search_key,
     // Simple case. There is a child for the current key byte.
     const auto child_index{res.first};
     const auto* const child{res.second};
-    if (UNODB_DETAIL_UNLIKELY(!try_push(node, remaining_key[0], child_index,
-                                        key_prefix, node_critical_section)))
-      return false;  // LCOV_EXCL_LINE
+    push(node, remaining_key[0], child_index, key_prefix,
+         node_critical_section);
     if constexpr (art_policy::can_eliminate_leaf) {
       if (inode->is_value_in_slot(node_type, child_index)) {
         // Value-in-slot: child is a packed value, not a subtree pointer.
@@ -4435,8 +4412,7 @@ bool olc_db<Key, Value>::iterator::try_seek(art_key_type search_key,
         if (UNODB_DETAIL_UNLIKELY(
                 !parent_critical_section.try_read_unlock()))  // unlock parent
           return false;                                       // LCOV_EXCL_LINE
-        if (UNODB_DETAIL_UNLIKELY(!try_push_leaf(node, node_critical_section)))
-          return false;  // LCOV_EXCL_LINE
+        push_leaf(node, node_critical_section);
         if (UNODB_DETAIL_UNLIKELY(
                 !node_critical_section.try_read_unlock()))  // unlock node
           return false;                                     // LCOV_EXCL_LINE
@@ -4485,8 +4461,7 @@ bool olc_db<Key, Value>::iterator::try_left_most_traversal(
       return false;  // LCOV_EXCL_LINE
     const auto node_type = node.type();
     if (node_type == node_type::LEAF) {
-      if (UNODB_DETAIL_UNLIKELY(!try_push_leaf(node, node_critical_section)))
-        return false;  // LCOV_EXCL_LINE
+      push_leaf(node, node_critical_section);
       return UNODB_DETAIL_LIKELY(node_critical_section.try_read_unlock());
     }
     // recursive descent.
@@ -4494,14 +4469,12 @@ bool olc_db<Key, Value>::iterator::try_left_most_traversal(
     const auto t =
         inode->begin(node_type);  // first chold of current internal node
     if (UNODB_DETAIL_UNLIKELY(!node_critical_section.check())) return false;
-    if (UNODB_DETAIL_UNLIKELY(!try_push(t, node_critical_section)))
-      return false;  // LCOV_EXCL_LINE
+    push(t, node_critical_section);
     if constexpr (art_policy::can_eliminate_leaf) {
       if (inode->is_value_in_slot(node_type, t.child_index)) {
         node = inode->get_child(node_type, t.child_index);
         if (UNODB_DETAIL_UNLIKELY(!node_critical_section.check())) return false;
-        if (UNODB_DETAIL_UNLIKELY(!try_push_leaf(node, node_critical_section)))
-          return false;  // LCOV_EXCL_LINE
+        push_leaf(node, node_critical_section);
         return UNODB_DETAIL_LIKELY(node_critical_section.try_read_unlock());
       }
     }
@@ -4540,8 +4513,7 @@ bool olc_db<Key, Value>::iterator::try_right_most_traversal(
       return false;  // LCOV_EXCL_LINE
     const auto node_type = node.type();
     if (node_type == node_type::LEAF) {
-      if (UNODB_DETAIL_UNLIKELY(!try_push_leaf(node, node_critical_section)))
-        return false;  // LCOV_EXCL_LINE
+      push_leaf(node, node_critical_section);
       return UNODB_DETAIL_LIKELY(node_critical_section.try_read_unlock());
     }
     // recursive descent.
@@ -4549,14 +4521,12 @@ bool olc_db<Key, Value>::iterator::try_right_most_traversal(
     const auto t =
         inode->last(node_type);  // last child of current internal node
     if (UNODB_DETAIL_UNLIKELY(!node_critical_section.check())) return false;
-    if (UNODB_DETAIL_UNLIKELY(!try_push(t, node_critical_section)))
-      return false;  // LCOV_EXCL_LINE
+    push(t, node_critical_section);
     if constexpr (art_policy::can_eliminate_leaf) {
       if (inode->is_value_in_slot(node_type, t.child_index)) {
         node = inode->get_child(node_type, t.child_index);
         if (UNODB_DETAIL_UNLIKELY(!node_critical_section.check())) return false;
-        if (UNODB_DETAIL_UNLIKELY(!try_push_leaf(node, node_critical_section)))
-          return false;  // LCOV_EXCL_LINE
+        push_leaf(node, node_critical_section);
         return UNODB_DETAIL_LIKELY(node_critical_section.try_read_unlock());
       }
     }


### PR DESCRIPTION
try_push(), its iter_result overload, and try_push_leaf() all ended in an
unconditional return true;. None had a path yielding false, so all 21 call
sites wrapped them in a guard that could never fire:

  if (UNODB_DETAIL_UNLIKELY(!try_push(...)))
    return false;  // LCOV_EXCL_LINE

The bool is vestigial rather than reserved. At d0516488 try_push() took the
key-prefix snapshot itself and had a real failure path, if (!rcs.check())
return false;. 391d2f10 ("Variable length key support.") moved the snapshot
to a caller-supplied prefix parameter and deleted that check, which was the
only return false; any of the three ever had. try_push_leaf() has been
unconditionally true since it was introduced.

Making them void and renaming to push()/push_leaf() also restores two
conventions. optimistic_lock.hpp's API conventions state that bool-returning
try_ methods return false when a concurrent write lock requires a restart -
these returned false never. And the single-threaded twins db::iterator::push()
and push_leaf() are already void and unprefixed, which the OLC side now
matches; the read_critical_section parameter still marks the OLC context. The
three were also the only try_ members in the file without [[nodiscard]], which
a void return makes moot.

The 21 removed markers are worth more than the dead branches they hid.
LCOV_EXCL_LINE claims a line cannot be tested by short deterministic tests,
so applying it to unreachable code misdescribes it - and these accounted for
21 of the 148 markers in the file, obscuring the genuine check() and
try_read_unlock() restart guards beside them, none of which this commit
touches.

No test changes: the removed lines were never executed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjJjyStJzoSiiH4yFjeNKc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified internal iterator stack insertion handling by using direct insertion procedures.
  - Updated traversal, seeking, and descent logic while preserving existing lock and version validation behavior.

- **Documentation**
  - Corrected internal documentation references to match the updated iterator operation names.

- **Behavior**
  - No user-facing functionality or externally visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->