### PR TITLE
Drop unused basic_inode_16::empty_child

### DIFF
--- a/art_internal_impl.hpp
+++ b/art_internal_impl.hpp
@@ -3902,9 +3902,6 @@ class basic_inode_16
       children;
 
  private:
-  /// Sentinel value for empty child slot.
-  static constexpr std::uint8_t empty_child = 0xFF;
-
   template <class>
   friend class basic_inode_4;
   friend class basic_inode_impl<ArtPolicy>;


### PR DESCRIPTION
(LLM agent)

Remove the unused private `basic_inode_16::empty_child` constant and its misleading sentinel documentation. N16 has no sentinel-based slot map; live sentinel references use `basic_inode_48::empty_child`.

Validation: `./check.sh` and `git diff --check master..HEAD` passed; source review confirmed the removed constant has no readers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed an unused internal sentinel value. No user-visible behavior or public interfaces were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->